### PR TITLE
DM-37933: Better testing of tag parsing

### DIFF
--- a/src/jupyterlabcontroller/models/tag.py
+++ b/src/jupyterlabcontroller/models/tag.py
@@ -51,7 +51,7 @@ TAG: Dict[str, str] = {
     # exp_flattened_build
     "experimental": r"(?:exp)",
     # c0020.002
-    "cycle": r"_(?P<ctag>c|csal)(?P<cycle>\d+)\.(?P<cbuild>\d+)",
+    "cycle": r"_c(?P<cycle>\d+)\.(?P<cbuild>\d+)",
     # _whatever_your_little_heart_desires
     "rest": r"_(?P<rest>.*)",
 }
@@ -220,7 +220,6 @@ class StandaloneRSPTag:
         md = match.groupdict()
         name = tag
         semver = None
-        ctag = md.get("ctag")
         cycle = md.get("cycle")
         cbuild = md.get("cbuild")
         cycle_int = None
@@ -245,7 +244,7 @@ class StandaloneRSPTag:
                 name = f"Experimental {temp_ptag.display_name}"
         else:
             # Everything else does get an actual semantic version
-            build = cls._build_component(cycle, cbuild, ctag, rest)
+            build = cls._build_component(cycle, cbuild, rest)
             typename = StandaloneRSPTag.prettify_tag(tagtype.name)
             restname = name[2:]
             if (
@@ -317,7 +316,6 @@ class StandaloneRSPTag:
         cls,
         cycle: str | None,
         cbuild: str | None,
-        ctag: str | None,
         rest: Optional[str] = None,
     ) -> str | None:
         """Determine the build component of the semantic version.
@@ -328,9 +326,6 @@ class StandaloneRSPTag:
             The cycle number, if any.
         cbuild
             The build number within a cycle, if any.
-        ctag
-            The leading tag for the cycle, either ``c`` (preferred) or
-            ``csal`` (legacy).
         rest
             Any trailing part of the version.
 
@@ -348,9 +343,9 @@ class StandaloneRSPTag:
         # Add on the cycle if one is available.
         if cycle is not None:
             if rest:
-                return f"{ctag}{cycle}.{cbuild}_{rest}"
+                return f"c{cycle}.{cbuild}_{rest}"
             else:
-                return f"{ctag}{cycle}.{cbuild}"
+                return f"c{cycle}.{cbuild}"
         else:
             return rest if rest else None
 

--- a/src/jupyterlabcontroller/models/tag.py
+++ b/src/jupyterlabcontroller/models/tag.py
@@ -182,7 +182,7 @@ class StandaloneRSPTag:
             match = re.compile(regexp).match(tag)
             if not match:
                 continue
-            display_name, semver, cycle = StandaloneRSPTag.extract_metadata(
+            display_name, semver, cycle = cls.extract_metadata(
                 match=match, tag=tag, tagtype=tagtype
             )
             return cls(
@@ -211,11 +211,9 @@ class StandaloneRSPTag:
         title case."""
         return tag.replace("_", " ").title()
 
-    @staticmethod
+    @classmethod
     def extract_metadata(
-        match: Match,
-        tag: str,
-        tagtype: RSPTagType,
+        cls, match: Match, tag: str, tagtype: RSPTagType
     ) -> Tuple[str, Optional[VersionInfo], Optional[int]]:
         """Return a display name, semantic version (optional), and cycle
         (optional) from match, tag, and type."""
@@ -247,9 +245,7 @@ class StandaloneRSPTag:
                 name = f"Experimental {temp_ptag.display_name}"
         else:
             # Everything else does get an actual semantic version
-            build = StandaloneRSPTag.trailing_parts_to_semver_build_component(
-                cycle, cbuild, ctag, rest
-            )
+            build = cls._build_component(cycle, cbuild, ctag, rest)
             typename = StandaloneRSPTag.prettify_tag(tagtype.name)
             restname = name[2:]
             if (
@@ -316,33 +312,47 @@ class StandaloneRSPTag:
             return None
         return int(n)
 
-    @staticmethod
-    def trailing_parts_to_semver_build_component(
-        cycle: Optional[str],
-        cbuild: Optional[str],
-        ctag: Optional[str],  # if present, either 'c' or 'csal'
+    @classmethod
+    def _build_component(
+        cls,
+        cycle: str | None,
+        cbuild: str | None,
+        ctag: str | None,
         rest: Optional[str] = None,
-    ) -> Optional[str]:
-        """This takes care of massaging the cycle components, and 'rest', into
-        a semver-compatible buildstring, which is dot-separated and can only
-        contain alphanumerics.  See SQR-059 for how it's used.
+    ) -> str | None:
+        """Determine the build component of the semantic version.
+
+        Parameters
+        ----------
+        cycle
+            The cycle number, if any.
+        cbuild
+            The build number within a cycle, if any.
+        ctag
+            The leading tag for the cycle, either ``c`` (preferred) or
+            ``csal`` (legacy).
+        rest
+            Any trailing part of the version.
+
+        Returns
+        -------
+        str or None
+            What to put in the build component of the semantic version.
         """
-        if cycle:
+        # semver build components may only contain periods and alphanumerics,
+        # so replace underscores with periods and then remove all other
+        # characters.
+        if rest:
+            rest = re.sub(r"[^\w.]+", "", rest.replace("_", "."))
+
+        # Add on the cycle if one is available.
+        if cycle is not None:
             if rest:
-                # Cycle must always precede rest
-                rest = f"{ctag}{cycle}.{cbuild}_{rest}"
+                return f"{ctag}{cycle}.{cbuild}_{rest}"
             else:
-                rest = f"{ctag}{cycle}.{cbuild}"
-        # We're done with cycle components now.
-        if not rest:
-            return None
-        rest = rest.replace("_", ".")
-        pat = re.compile(r"[^\w|\.]+")  # Identify all non alphanum, non-dots
-        # Throw away all of those after turning underscores to dots.
-        rest = pat.sub("", rest)
-        if not rest:  # if we are left with an empty string, return None
-            return None
-        return rest
+                return f"{ctag}{cycle}.{cbuild}"
+        else:
+            return rest if rest else None
 
     def compare(self, other: "StandaloneRSPTag") -> int:
         """This is modelled after semver.compare, but raises an exception

--- a/src/jupyterlabcontroller/models/tag.py
+++ b/src/jupyterlabcontroller/models/tag.py
@@ -171,10 +171,6 @@ class StandaloneRSPTag:
     example: 20
     """
 
-    # Required for SemanticVersion
-    class Config:
-        arbitrary_types_allowed = True
-
     @classmethod
     def parse_tag(
         cls,

--- a/tests/tag_test.py
+++ b/tests/tag_test.py
@@ -2,9 +2,46 @@
 
 from __future__ import annotations
 
+import pytest
 from semver import VersionInfo
 
-from jupyterlabcontroller.models.tag import RSPTagType, StandaloneRSPTag
+from jupyterlabcontroller.models.tag import (
+    IncomparableImageTypesError,
+    RSPTagType,
+    StandaloneRSPTag,
+)
+
+
+def test_compare_tag() -> None:
+    """Test comparisons of StandaloneRSPTag objects."""
+    one = StandaloneRSPTag.parse_tag("r21_0_1")
+    two = StandaloneRSPTag.parse_tag("r21_0_2")
+    assert one == one
+    assert one <= one
+    assert one >= one
+    assert one != two
+    assert one < two
+    assert one <= two
+    assert two >= one
+
+    three = StandaloneRSPTag.parse_tag("d_2023_02_09")
+    assert three == three
+    with pytest.raises(IncomparableImageTypesError):
+        one == three
+    with pytest.raises(IncomparableImageTypesError):
+        one < three
+    with pytest.raises(IncomparableImageTypesError):
+        one <= three
+
+    four = StandaloneRSPTag.parse_tag("d_2023_02_10_c0030.004")
+    assert three != four
+    assert three < four
+
+    exp_one = StandaloneRSPTag.parse_tag("exp_20230209")
+    exp_two = StandaloneRSPTag.parse_tag("exp_random")
+    assert exp_one == exp_one
+    assert exp_one != exp_two
+    assert exp_one < exp_two
 
 
 def test_parse_tag() -> None:
@@ -171,6 +208,13 @@ def test_parse_tag() -> None:
             tag="MiXeD_CaSe_TaG",
             image_type=RSPTagType.UNKNOWN,
             display_name="MiXeD_CaSe_TaG",
+            semantic_version=None,
+            cycle=None,
+        ),
+        "": StandaloneRSPTag(
+            tag="latest",
+            image_type=RSPTagType.UNKNOWN,
+            display_name="latest",
             semantic_version=None,
             cycle=None,
         ),

--- a/tests/tag_test.py
+++ b/tests/tag_test.py
@@ -1,0 +1,180 @@
+"""Tests of Docker image tag analysis and deduplication."""
+
+from __future__ import annotations
+
+from semver import VersionInfo
+
+from jupyterlabcontroller.models.tag import RSPTagType, StandaloneRSPTag
+
+
+def test_parse_tag() -> None:
+    """Parse tags into StandaloneRSPTag objects."""
+    test_cases = {
+        "r21_0_1": StandaloneRSPTag(
+            tag="r21_0_1",
+            image_type=RSPTagType.RELEASE,
+            display_name="Release r21.0.1",
+            semantic_version=VersionInfo(21, 0, 1),
+            cycle=None,
+        ),
+        "r22_0_0_rc1": StandaloneRSPTag(
+            tag="r22_0_0_rc1",
+            image_type=RSPTagType.RELEASE_CANDIDATE,
+            display_name="Release Candidate r22.0.0-rc1",
+            semantic_version=VersionInfo(22, 0, 0, "rc1"),
+            cycle=None,
+        ),
+        "w_2021_22": StandaloneRSPTag(
+            tag="w_2021_22",
+            image_type=RSPTagType.WEEKLY,
+            display_name="Weekly 2021_22",
+            semantic_version=VersionInfo(2021, 22, 0),
+            cycle=None,
+        ),
+        "d_2021_05_27": StandaloneRSPTag(
+            tag="d_2021_05_27",
+            image_type=RSPTagType.DAILY,
+            display_name="Daily 2021_05_27",
+            semantic_version=VersionInfo(2021, 5, 27),
+            cycle=None,
+        ),
+        "r21_0_1_c0020.001": StandaloneRSPTag(
+            tag="r21_0_1_c0020.001",
+            image_type=RSPTagType.RELEASE,
+            display_name="Release r21.0.1 (SAL Cycle 0020, Build 001)",
+            semantic_version=VersionInfo(21, 0, 1, None, "c0020.001"),
+            cycle=20,
+        ),
+        "r22_0_0_rc1_c0020.001": StandaloneRSPTag(
+            tag="r22_0_0_rc1_c0020.001",
+            image_type=RSPTagType.RELEASE_CANDIDATE,
+            display_name=(
+                "Release Candidate r22.0.0-rc1 (SAL Cycle 0020, Build 001)"
+            ),
+            semantic_version=VersionInfo(22, 0, 0, "rc1", "c0020.001"),
+            cycle=20,
+        ),
+        "w_2021_22_c0020.001": StandaloneRSPTag(
+            tag="w_2021_22_c0020.001",
+            image_type=RSPTagType.WEEKLY,
+            display_name="Weekly 2021_22 (SAL Cycle 0020, Build 001)",
+            semantic_version=VersionInfo(2021, 22, 0, None, "c0020.001"),
+            cycle=20,
+        ),
+        "d_2021_05_27_c0020.001": StandaloneRSPTag(
+            tag="d_2021_05_27_c0020.001",
+            image_type=RSPTagType.DAILY,
+            display_name="Daily 2021_05_27 (SAL Cycle 0020, Build 001)",
+            semantic_version=VersionInfo(2021, 5, 27, None, "c0020.001"),
+            cycle=20,
+        ),
+        "r21_0_1_20210527": StandaloneRSPTag(
+            tag="r21_0_1_20210527",
+            image_type=RSPTagType.RELEASE,
+            display_name="Release r21.0.1 [20210527]",
+            semantic_version=VersionInfo(21, 0, 1, None, "20210527"),
+            cycle=None,
+        ),
+        "r22_0_0_rc1_20210527": StandaloneRSPTag(
+            tag="r22_0_0_rc1_20210527",
+            image_type=RSPTagType.RELEASE_CANDIDATE,
+            display_name="Release Candidate r22.0.0-rc1 [20210527]",
+            semantic_version=VersionInfo(22, 0, 0, "rc1", "20210527"),
+            cycle=None,
+        ),
+        "w_2021_22_20210527": StandaloneRSPTag(
+            tag="w_2021_22_20210527",
+            image_type=RSPTagType.WEEKLY,
+            display_name="Weekly 2021_22 [20210527]",
+            semantic_version=VersionInfo(2021, 22, 0, None, "20210527"),
+            cycle=None,
+        ),
+        "d_2021_05_27_20210527": StandaloneRSPTag(
+            tag="d_2021_05_27_20210527",
+            image_type=RSPTagType.DAILY,
+            display_name="Daily 2021_05_27 [20210527]",
+            semantic_version=VersionInfo(2021, 5, 27, None, "20210527"),
+            cycle=None,
+        ),
+        "r21_0_1_c0020.001_20210527": StandaloneRSPTag(
+            tag="r21_0_1_c0020.001_20210527",
+            image_type=RSPTagType.RELEASE,
+            display_name=(
+                "Release r21.0.1 (SAL Cycle 0020, Build 001) [20210527]"
+            ),
+            semantic_version=VersionInfo(21, 0, 1, None, "c0020.001.20210527"),
+            cycle=20,
+        ),
+        "r22_0_0_rc1_c0020.001_20210527": StandaloneRSPTag(
+            tag="r22_0_0_rc1_c0020.001_20210527",
+            image_type=RSPTagType.RELEASE_CANDIDATE,
+            display_name=(
+                "Release Candidate r22.0.0-rc1 (SAL Cycle 0020, Build 001)"
+                " [20210527]"
+            ),
+            semantic_version=VersionInfo(
+                22, 0, 0, "rc1", "c0020.001.20210527"
+            ),
+            cycle=20,
+        ),
+        "w_2021_22_c0020.001_20210527": StandaloneRSPTag(
+            tag="w_2021_22_c0020.001_20210527",
+            image_type=RSPTagType.WEEKLY,
+            display_name=(
+                "Weekly 2021_22_ (SAL Cycle 0020, Build 001) [20210527]"
+            ),
+            semantic_version=VersionInfo(
+                2021, 22, 0, None, "c0020.001.20210527"
+            ),
+            cycle=20,
+        ),
+        "d_2021_05_27_c0020.001_20210527": StandaloneRSPTag(
+            tag="d_2021_05_27_c0020.001_20210527",
+            image_type=RSPTagType.DAILY,
+            display_name=(
+                "Daily 2021_05_27 (SAL Cycle 0020, Build 001) [20210527]"
+            ),
+            semantic_version=VersionInfo(
+                2021, 5, 27, None, "c0020.001.20210527"
+            ),
+            cycle=20,
+        ),
+        "recommended": StandaloneRSPTag(
+            tag="recommended",
+            image_type=RSPTagType.UNKNOWN,
+            display_name="recommended",
+            semantic_version=None,
+            cycle=None,
+        ),
+        "exp_random": StandaloneRSPTag(
+            tag="exp_random",
+            image_type=RSPTagType.EXPERIMENTAL,
+            display_name="Experimental random",
+            semantic_version=None,
+            cycle=None,
+        ),
+        "exp_w_2021_22": StandaloneRSPTag(
+            tag="exp_w_2021_22",
+            image_type=RSPTagType.EXPERIMENTAL,
+            display_name="Experimental Weekly 2021_22",
+            semantic_version=None,
+            cycle=None,
+        ),
+        "not_a_normal_format": StandaloneRSPTag(
+            tag="not_a_normal_format",
+            image_type=RSPTagType.UNKNOWN,
+            display_name="not_a_normal_format",
+            semantic_version=None,
+            cycle=None,
+        ),
+        "MiXeD_CaSe_TaG": StandaloneRSPTag(
+            tag="MiXeD_CaSe_TaG",
+            image_type=RSPTagType.UNKNOWN,
+            display_name="MiXeD_CaSe_TaG",
+            semantic_version=None,
+            cycle=None,
+        ),
+    }
+
+    for tag, expected in test_cases.items():
+        assert StandaloneRSPTag.parse_tag(tag) == expected


### PR DESCRIPTION
Import the tag parsing tests from cachemachine. There were almost no tests of the tag parsing logic and this (for now until we create a shared model library) will be the canonical location for this code, so import the tests from cachemachine and reformat them a little to be less verbose. Anticipate eventually moving the tag out of models to its own abstract data type in the naming of the test suite.

Refactor the construction of the build component in tags to fix a bug I noticed (`|` were left behind in the build component) and make the code a bit easier to follow.