### PR TITLE
DM-37933: Simplify and further test Docker credential handling

### DIFF
--- a/src/jupyterlabcontroller/factory.py
+++ b/src/jupyterlabcontroller/factory.py
@@ -128,16 +128,25 @@ class Factory:
         async with aclosing(factory):
             yield factory
 
-    def __init__(
-        self,
-        context: ProcessContext,
-        logger: BoundLogger,
-    ) -> None:
+    def __init__(self, context: ProcessContext, logger: BoundLogger) -> None:
         self._context = context
         self.logger = logger
 
     async def aclose(self) -> None:
         await self._context.aclose()
+
+    def create_docker_storage(self) -> DockerStorageClient:
+        """Create a Docker storage client."""
+        return DockerStorageClient(
+            host=self._context.config.images.registry,
+            repository=self._context.config.images.repository,
+            recommended_tag=self._context.config.images.recommended_tag,
+            http_client=self._context.http_client,
+            logger=self.logger,
+            credentials=self._context.docker_credentials.get(
+                self._context.config.images.registry,
+            ),
+        )
 
     def set_logger(self, logger: BoundLogger) -> None:
         self.logger = logger

--- a/src/jupyterlabcontroller/models/v1/prepuller_config.py
+++ b/src/jupyterlabcontroller/models/v1/prepuller_config.py
@@ -138,30 +138,30 @@ class PrepullerConfiguration(CamelCaseModel):
 
     @property
     def registry(self) -> str:
-        # Return the image registry (hostname and optional port)
-        if self.gar is not None:
+        """The image registry (hostname and optional port)."""
+        if self.gar:
             return self.gar.registry
-        if self.docker is None:
-            # The validator keeps this from happening, but mypy can't tell
-            raise RuntimeError(
-                "Exactly one of 'docker' or 'gar' must be defined"
-            )
-        return self.docker.registry
+        elif self.docker:
+            return self.docker.registry
+        else:
+            # This is impossible due to validation, but mypy doesn't know that.
+            raise RuntimeError("PrepullerConfiguration with no docker or gar")
 
     @property
     def repository(self) -> str:
-        # Return the image repository (docker reference without the host/tag)
-        if self.gar is not None:
-            r = (
-                f"/{self.gar.project_id}/{self.gar.repository}/"
-                f"{self.gar.image}"
+        """The image repository (Docker reference without the host or tag)."""
+        if self.gar:
+            return (
+                f"{self.gar.project_id}/{self.gar.repository}"
+                f"/{self.gar.image}"
             )
+        elif self.docker:
+            return self.docker.repository
         else:
-            if self.docker is not None:
-                r = f"/{self.docker.repository}"
-        return r
+            # This is impossible due to validation, but mypy doesn't know that.
+            raise RuntimeError("PrepullerConfiguration with no docker or gar")
 
     @property
     def path(self) -> str:
         # Return the canonical path to the set of tagged images
-        return f"{self.registry}{self.repository}"
+        return f"{self.registry}/{self.repository}"

--- a/src/jupyterlabcontroller/storage/docker.py
+++ b/src/jupyterlabcontroller/storage/docker.py
@@ -12,15 +12,32 @@ from ..util import extract_untagged_path_from_image_ref
 
 
 class DockerStorageClient:
-    """Simple client for querying Docker registry."""
+    """Client to query the Docker API for image information.
+
+    Parameters
+    ----------
+    host
+        Docker registry API host.
+    repository
+        Image repository to query (for example, ``lsstsqre/sciplat-lab``).
+    recommended_tag
+        The tag indicating the recommended image.
+    http_client
+        Client to use to make requests.
+    logger
+        Logger for log messages.
+    credentials
+        Authentication credentials for the Docker API server.
+    """
 
     def __init__(
         self,
-        logger: BoundLogger,
+        *,
         host: str,
         repository: str,
         recommended_tag: str,
         http_client: AsyncClient,
+        logger: BoundLogger,
         credentials: Optional[DockerCredentials] = None,
     ) -> None:
         """Create a new Docker Client.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ from starlette.datastructures import Headers
 from jupyterlabcontroller.config import Configuration
 from jupyterlabcontroller.dependencies.config import configuration_dependency
 from jupyterlabcontroller.dependencies.context import ContextDependency
-from jupyterlabcontroller.factory import Context
+from jupyterlabcontroller.factory import Context, Factory
 from jupyterlabcontroller.main import create_app
 
 from .settings import TestObjectFactory, test_object_factory
@@ -109,6 +109,13 @@ async def app_client(
         base_url=config.runtime.instance_url,
     ) as client:
         yield client
+
+
+@pytest_asyncio.fixture
+async def factory(config: Configuration) -> AsyncIterator[Factory]:
+    """Create a component factory for tests."""
+    async with Factory.standalone(config) as factory:
+        yield factory
 
 
 def make_request(token: str) -> Request:

--- a/tests/storage/docker_test.py
+++ b/tests/storage/docker_test.py
@@ -6,65 +6,52 @@ import os
 
 import pytest
 import respx
-import structlog
-from httpx import AsyncClient
 
-from jupyterlabcontroller.models.domain.docker import DockerCredentials
-from jupyterlabcontroller.storage.docker import DockerStorageClient
+from jupyterlabcontroller.config import Configuration
+from jupyterlabcontroller.factory import Factory
 
 from ..support.docker import mock_docker
 
 
 @pytest.mark.asyncio
-async def test_api(respx_mock: respx.Router) -> None:
+async def test_api(
+    config: Configuration, factory: Factory, respx_mock: respx.Router
+) -> None:
     tag_names = {"w_2021_21", "w_2021_22", "d_2021_06_14", "d_2021_06_15"}
     tags = {t: "sha256:" + os.urandom(32).hex() for t in tag_names}
-    mock = mock_docker(
+    docker_credentials = factory.get_docker_credentials()
+    credentials = docker_credentials.get(config.images.registry)
+    assert credentials
+    mock_docker(
         respx_mock,
-        host="registry.hub.docker.com",
-        repository="lsstsqre/sciplat-lab",
+        host=config.images.registry,
+        repository=config.images.repository,
+        credentials=credentials,
         tags=tags,
     )
-
-    docker = DockerStorageClient(
-        structlog.get_logger(__name__),
-        "registry.hub.docker.com",
-        "lsstsqre/sciplat-lab",
-        "recommended",
-        AsyncClient(),
-        DockerCredentials(
-            registry_host="registry.hub.docker.com",
-            username=mock.username,
-            password=mock.password,
-        ),
-    )
+    docker = factory.create_docker_storage()
     assert set(await docker.list_tags()) == tag_names
     assert await docker.get_image_digest("w_2021_21") == tags["w_2021_21"]
     assert await docker.get_image_digest("w_2021_22") == tags["w_2021_22"]
 
 
 @pytest.mark.asyncio
-async def test_bearer_auth(respx_mock: respx.Router) -> None:
+async def test_bearer_auth(
+    config: Configuration, factory: Factory, respx_mock: respx.Router
+) -> None:
+    assert config.images.docker
     tags = {"r23_0_4": "sha256:" + os.urandom(32).hex()}
-    mock = mock_docker(
+    docker_credentials = factory.get_docker_credentials()
+    credentials = docker_credentials.get(config.images.docker.registry)
+    assert credentials
+    mock_docker(
         respx_mock,
-        host="registry.hub.docker.com",
-        repository="lsstsqre/sciplat-lab",
+        host=config.images.docker.registry,
+        repository=config.images.docker.repository,
+        credentials=credentials,
         tags=tags,
         require_bearer=True,
     )
-
-    docker = DockerStorageClient(
-        structlog.get_logger(__name__),
-        "registry.hub.docker.com",
-        "lsstsqre/sciplat-lab",
-        "recommended",
-        AsyncClient(),
-        DockerCredentials(
-            registry_host="registry.hub.docker.com",
-            username=mock.username,
-            password=mock.password,
-        ),
-    )
+    docker = factory.create_docker_storage()
     assert await docker.list_tags() == ["r23_0_4"]
     assert await docker.get_image_digest("r23_0_4") == tags["r23_0_4"]

--- a/tests/storage/docker_test.py
+++ b/tests/storage/docker_test.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-from base64 import b64encode
 
 import pytest
 import respx
@@ -37,9 +36,6 @@ async def test_api(respx_mock: respx.Router) -> None:
             registry_host="registry.hub.docker.com",
             username=mock.username,
             password=mock.password,
-            base64_auth=b64encode(
-                f"{mock.username}:{mock.password}".encode()
-            ).decode(),
         ),
     )
     assert set(await docker.list_tags()) == tag_names
@@ -68,9 +64,6 @@ async def test_bearer_auth(respx_mock: respx.Router) -> None:
             registry_host="registry.hub.docker.com",
             username=mock.username,
             password=mock.password,
-            base64_auth=b64encode(
-                f"{mock.username}:{mock.password}".encode()
-            ).decode(),
         ),
     )
     assert await docker.list_tags() == ["r23_0_4"]


### PR DESCRIPTION
Rather than using separate credentials for the Docker storage layer test, plumb through the dynamic loading of credentials and use the default credentials for the test configuration, along with the default registry and repository. This enables creating the Docker storage object via the factory, so provide a test factory as a fixture and add a method to create a Docker storage object.

Simplify the DockerCredentials class to stop storing username and password in two different forms and instead derive the other forms from username and password.

This work uncovered a latent minor bug in the Docker storage layer, where a spurious extra slash was added to the URL for getting tag and image information. The Docker API apparently swallows this but respx doesn't, so redo the repository and path properties of the prepuller configuration to remove the unwanted leading slash in the repository.