### PR TITLE
DM-37933: Config and Docker credentials refactor

### DIFF
--- a/src/jupyterlabcontroller/constants.py
+++ b/src/jupyterlabcontroller/constants.py
@@ -1,9 +1,11 @@
-"""Constants for jupyterlab-controller
-"""
+"""Global constants."""
+
 import datetime
 from pathlib import Path
 
-CONFIGURATION_PATH = "/etc/nublado/config.yaml"
+CONFIGURATION_PATH = Path("/etc/nublado/config.yaml")
+"""Path to controller configuration."""
+
 DOCKER_SECRETS_PATH = "/etc/secrets/.dockerconfigjson"
 
 ADMIN_SCOPE = "admin:jupyterlab"

--- a/src/jupyterlabcontroller/constants.py
+++ b/src/jupyterlabcontroller/constants.py
@@ -4,9 +4,10 @@ import datetime
 from pathlib import Path
 
 CONFIGURATION_PATH = Path("/etc/nublado/config.yaml")
-"""Path to controller configuration."""
+"""Default path to controller configuration."""
 
-DOCKER_SECRETS_PATH = "/etc/secrets/.dockerconfigjson"
+DOCKER_SECRETS_PATH = Path("/etc/secrets/.dockerconfigjson")
+"""Default path to the Docker API secrets."""
 
 ADMIN_SCOPE = "admin:jupyterlab"
 USER_SCOPE = "exec:notebook"

--- a/src/jupyterlabcontroller/dependencies/config.py
+++ b/src/jupyterlabcontroller/dependencies/config.py
@@ -1,4 +1,6 @@
 """Configuration dependency."""
+
+from pathlib import Path
 from typing import Optional
 
 from ..config import Configuration
@@ -6,30 +8,30 @@ from ..constants import CONFIGURATION_PATH
 
 
 class ConfigurationDependency:
-    def __init__(self, filename: str = CONFIGURATION_PATH) -> None:
-        self._filename: str = filename
+    def __init__(self, path: Path = CONFIGURATION_PATH) -> None:
+        self._path = path
         self._config: Optional[Configuration] = None
-        #  Defer initialization until first use.
 
-    async def __call__(
-        self,
-    ) -> Configuration:
+    async def __call__(self) -> Configuration:
         return self.config
 
     @property
     def config(self) -> Configuration:
+        """Load configuration if needed and return it.
+
+        Returns
+        -------
+        jupyterlabcontroller.config.Configuration
+            Controller configuration.
+        """
         if self._config is None:
-            self._config = Configuration.from_file(
-                self._filename,
-            )
+            self._config = Configuration.from_file(self._path)
         return self._config
 
-    def set_filename(self, path: str) -> None:
-        """Change the settings path and reload."""
-        self._filename = path
-        self._config = Configuration.from_file(
-            filename=self._filename,
-        )
+    def set_path(self, path: Path) -> None:
+        """Change the configuration path and reload."""
+        self._path = path
+        self._config = Configuration.from_file(path)
 
 
 configuration_dependency = ConfigurationDependency()

--- a/src/jupyterlabcontroller/factory.py
+++ b/src/jupyterlabcontroller/factory.py
@@ -91,7 +91,7 @@ class ProcessContext:
                 ),
                 logger=logger,
                 config=config.images,
-                namespace=config.runtime.namespace_prefix,
+                namespace=config.lab.namespace_prefix,
                 arbitrator=PrepullerArbitrator(
                     state=prepuller_state,
                     tag_client=PrepullerTagClient(
@@ -253,8 +253,8 @@ class Context:
     @property
     def lab_manager(self) -> LabManager:
         return LabManager(
-            instance_url=self.config.runtime.instance_url,
-            manager_namespace=self.config.runtime.namespace_prefix,
+            instance_url=self.config.base_url,
+            manager_namespace=self.config.lab.namespace_prefix,
             user_map=self.user_map,
             event_manager=self.event_manager,
             logger=self.logger,
@@ -307,7 +307,7 @@ class Context:
 
     async def get_namespace(self) -> str:
         username = await self.get_username()
-        return f"{self.config.runtime.namespace_prefix}-{username}"
+        return f"{self.config.lab.namespace_prefix}-{username}"
 
     def rebind_logger(self, **values: Any) -> None:
         """Add the given values to the logging context."""

--- a/src/jupyterlabcontroller/factory.py
+++ b/src/jupyterlabcontroller/factory.py
@@ -147,9 +147,6 @@ class Factory:
     def get_k8s_client(self) -> ApiClient:
         return self._context.k8s_client
 
-    def get_docker_credentials(self) -> DockerCredentialStore:
-        return self._context.docker_credentials
-
     def get_user_map(self) -> UserMap:
         return self._context.user_map
 
@@ -192,10 +189,6 @@ class Context:
     @property
     def k8s_api_client(self) -> ApiClient:
         return self._factory.get_k8s_client()
-
-    @property
-    def docker_credentials(self) -> DockerCredentialStore:
-        return self._factory.get_docker_credentials()
 
     @property
     def prepuller_state(self) -> PrepullerState:
@@ -255,14 +248,6 @@ class Context:
         return K8sStorageClient(
             k8s_api=self.k8s_api_client,
             timeout=KUBERNETES_REQUEST_TIMEOUT,
-            logger=self.logger,
-        )
-
-    @property
-    def docker_client(self) -> DockerStorageClient:
-        return DockerStorageClient(
-            credentials=self.docker_credentials,
-            http_client=self.http_client,
             logger=self.logger,
         )
 

--- a/src/jupyterlabcontroller/factory.py
+++ b/src/jupyterlabcontroller/factory.py
@@ -87,7 +87,6 @@ class ProcessContext:
                     config=config.images,
                     logger=logger,
                 ),
-                recommended_tag=config.images.recommended_tag,
             ),
             docker_credentials=docker_credentials,
             user_map=UserMap(),

--- a/src/jupyterlabcontroller/factory.py
+++ b/src/jupyterlabcontroller/factory.py
@@ -1,6 +1,7 @@
+"""Component factory and global and per-request context management."""
+
 from contextlib import aclosing, asynccontextmanager
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any, AsyncIterator, List
 
 import structlog
@@ -10,13 +11,8 @@ from safir.dependencies.http_client import http_client_dependency
 from structlog.stdlib import BoundLogger
 
 from .config import Configuration
-from .constants import (
-    CONFIGURATION_PATH,
-    DOCKER_SECRETS_PATH,
-    KUBERNETES_REQUEST_TIMEOUT,
-)
+from .constants import KUBERNETES_REQUEST_TIMEOUT
 from .exceptions import InvalidUserError
-from .models.domain.docker import DockerCredentialsMap
 from .models.domain.usermap import UserMap
 from .models.v1.lab import UserInfo
 from .services.events import EventManager
@@ -27,7 +23,7 @@ from .services.prepuller.executor import PrepullerExecutor
 from .services.prepuller.state import PrepullerState
 from .services.prepuller.tag import PrepullerTagClient
 from .services.size import SizeManager
-from .storage.docker import DockerStorageClient
+from .storage.docker import DockerCredentialStore, DockerStorageClient
 from .storage.gafaelfawr import GafaelfawrStorageClient
 from .storage.k8s import K8sStorageClient
 
@@ -49,7 +45,7 @@ class ProcessContext:
     config: Configuration
     http_client: AsyncClient
     k8s_client: ApiClient
-    docker_credentials: DockerCredentialsMap
+    docker_credentials: DockerCredentialStore
     prepuller_executor: PrepullerExecutor
     user_map: UserMap
     event_manager: EventManager
@@ -59,14 +55,8 @@ class ProcessContext:
         prepuller_state = PrepullerState()
         k8s_api_client = ApiClient()
         logger = structlog.get_logger(config.safir.logger_name)
-        if config.runtime.path == CONFIGURATION_PATH:
-            credentials_file = DOCKER_SECRETS_PATH
-        else:
-            credentials_file = str(
-                Path(config.runtime.path).parent / "docker_config.json"
-            )
-        docker_credentials = DockerCredentialsMap(
-            logger=logger, filename=credentials_file
+        docker_credentials = DockerCredentialStore.from_path(
+            config.docker_secrets_path
         )
         return cls(
             config=config,
@@ -80,14 +70,9 @@ class ProcessContext:
                     logger=logger,
                 ),
                 docker_client=DockerStorageClient(
-                    host=config.images.registry,
-                    repository=config.images.repository,
-                    logger=logger,
+                    credentials=docker_credentials,
                     http_client=await http_client_dependency(),
-                    recommended_tag=config.images.recommended_tag,
-                    credentials=docker_credentials.get(
-                        config.images.registry,
-                    ),
+                    logger=logger,
                 ),
                 logger=logger,
                 config=config.images,
@@ -102,6 +87,7 @@ class ProcessContext:
                     config=config.images,
                     logger=logger,
                 ),
+                recommended_tag=config.images.recommended_tag,
             ),
             docker_credentials=docker_credentials,
             user_map=UserMap(),
@@ -138,14 +124,9 @@ class Factory:
     def create_docker_storage(self) -> DockerStorageClient:
         """Create a Docker storage client."""
         return DockerStorageClient(
-            host=self._context.config.images.registry,
-            repository=self._context.config.images.repository,
-            recommended_tag=self._context.config.images.recommended_tag,
+            credentials=self._context.docker_credentials,
             http_client=self._context.http_client,
             logger=self.logger,
-            credentials=self._context.docker_credentials.get(
-                self._context.config.images.registry,
-            ),
         )
 
     def set_logger(self, logger: BoundLogger) -> None:
@@ -166,7 +147,7 @@ class Factory:
     def get_k8s_client(self) -> ApiClient:
         return self._context.k8s_client
 
-    def get_docker_credentials(self) -> DockerCredentialsMap:
+    def get_docker_credentials(self) -> DockerCredentialStore:
         return self._context.docker_credentials
 
     def get_user_map(self) -> UserMap:
@@ -213,7 +194,7 @@ class Context:
         return self._factory.get_k8s_client()
 
     @property
-    def docker_credentials(self) -> DockerCredentialsMap:
+    def docker_credentials(self) -> DockerCredentialStore:
         return self._factory.get_docker_credentials()
 
     @property
@@ -280,14 +261,9 @@ class Context:
     @property
     def docker_client(self) -> DockerStorageClient:
         return DockerStorageClient(
-            host=self.config.images.registry,
-            repository=self.config.images.repository,
-            logger=self.logger,
+            credentials=self.docker_credentials,
             http_client=self.http_client,
-            credentials=self.docker_credentials.get(
-                self.config.images.registry,
-            ),
-            recommended_tag=self.config.images.recommended_tag,
+            logger=self.logger,
         )
 
     async def get_user(self) -> UserInfo:

--- a/src/jupyterlabcontroller/main.py
+++ b/src/jupyterlabcontroller/main.py
@@ -1,7 +1,6 @@
 """The main application factory for the jupyterlab-controller service."""
 
 from importlib.metadata import metadata, version
-from pathlib import Path
 from typing import Optional
 
 import structlog
@@ -38,7 +37,6 @@ fake_request = Request(
 
 def create_app(
     *,
-    config_dir: Optional[Path] = None,
     context_dependency: Optional[context.ContextDependency] = None,
 ) -> FastAPI:
     """Create the FastAPI application.
@@ -47,14 +45,6 @@ def create_app(
     typical for FastAPI) because some middleware depends on configuration
     settings and we therefore want to recreate the application between tests.
     """
-    # We need to be able to override the config location for testing
-    # and running locally.
-    #
-    # If config_dir is set, we will assume that it contains the path
-    # to a directory that contains both 'config.yaml' and
-    # 'docker_config.json'.
-    if config_dir is not None:
-        configuration_dependency.set_path(config_dir / "config.yaml")
     config = configuration_dependency.config
 
     # If ProcessContext is supplied, we use it instead of initializing a

--- a/src/jupyterlabcontroller/main.py
+++ b/src/jupyterlabcontroller/main.py
@@ -1,13 +1,7 @@
-"""The main application factory for the jupyterlab-controller service.
-
-Notes
------
-Be aware that, following the normal pattern for FastAPI services, the app is
-constructed when this module is loaded and is not deferred until a function is
-called.
-"""
+"""The main application factory for the jupyterlab-controller service."""
 
 from importlib.metadata import metadata, version
+from pathlib import Path
 from typing import Optional
 
 import structlog
@@ -44,7 +38,7 @@ fake_request = Request(
 
 def create_app(
     *,
-    config_dir: Optional[str] = None,
+    config_dir: Optional[Path] = None,
     context_dependency: Optional[context.ContextDependency] = None,
 ) -> FastAPI:
     """Create the FastAPI application.
@@ -52,30 +46,25 @@ def create_app(
     This is in a function rather than using a global variable (as is more
     typical for FastAPI) because some middleware depends on configuration
     settings and we therefore want to recreate the application between tests.
-
-    Stolen from Gafaelfawr.
     """
-
-    #
     # We need to be able to override the config location for testing
     # and running locally.
     #
     # If config_dir is set, we will assume that it contains the path
     # to a directory that contains both 'config.yaml' and
     # 'docker_config.json'.
-    #
+    if config_dir is not None:
+        configuration_dependency.set_path(config_dir / "config.yaml")
+    config = configuration_dependency.config
+
     # If ProcessContext is supplied, we use it instead of initializing a
     # new one.  The only way I can see to make the linkage at app startup
     # work right now is via a process global, which seems hideous.
-
-    if config_dir is not None:
-        configuration_dependency.set_filename(f"{config_dir}/config.yaml")
-    config = configuration_dependency.config
-
     if context_dependency is not None:
         global injected_context_dependency
         injected_context_dependency = context_dependency
 
+    # Configure logging.
     configure_logging(
         profile=config.safir.profile,
         log_level=config.safir.log_level,
@@ -83,6 +72,7 @@ def create_app(
     )
     configure_uvicorn_logging(config.safir.log_level)
 
+    # Create the application object.
     app = FastAPI(
         title=config.safir.name,
         description=metadata("jupyterlab-controller")["Summary"],
@@ -91,8 +81,6 @@ def create_app(
         docs_url=f"/{config.safir.root_endpoint}/docs",
         redoc_url=f"/{config.safir.root_endpoint}/redoc",
     )
-
-    """The main FastAPI application for jupyterlab-controller."""
 
     # Attach the routers.
     app.include_router(indexes.internal_index_router)
@@ -109,6 +97,7 @@ def create_app(
     app.on_event("startup")(startup_event)
     app.on_event("shutdown")(shutdown_event)
 
+    # Register middleware.
     app.add_middleware(XForwardedMiddleware)
 
     return app

--- a/src/jupyterlabcontroller/models/domain/docker.py
+++ b/src/jupyterlabcontroller/models/domain/docker.py
@@ -9,9 +9,6 @@ from typing import Self
 class DockerCredentials:
     """Holds the credentials for one Docker API server."""
 
-    registry_host: str
-    """Hostname of the server for which these credentials apply."""
-
     username: str
     """Authentication username."""
 
@@ -30,7 +27,7 @@ class DockerCredentials:
         return base64.b64encode(auth_data).decode()
 
     @classmethod
-    def from_config(cls, host: str, config: dict[str, str]) -> Self:
+    def from_config(cls, config: dict[str, str]) -> Self:
         """Create from a Docker config entry (such as a pull secret).
 
         This requires the ``auth`` field be set and ignores the ``username``
@@ -38,8 +35,6 @@ class DockerCredentials:
 
         Parameters
         ----------
-        host
-            The hostname of the server for which these credentials apply.
         config
             The entry for that hostname in the configuration.
 
@@ -50,7 +45,7 @@ class DockerCredentials:
         """
         basic_auth = base64.b64decode(config["auth"].encode()).decode()
         username, password = basic_auth.split(":", 1)
-        return cls(registry_host=host, username=username, password=password)
+        return cls(username=username, password=password)
 
     def to_config(self) -> dict[str, str]:
         """Convert the credentials to a Docker config entry.

--- a/src/jupyterlabcontroller/models/domain/docker.py
+++ b/src/jupyterlabcontroller/models/domain/docker.py
@@ -3,7 +3,7 @@
 import base64
 import json
 from dataclasses import dataclass
-from typing import Dict, Optional
+from typing import Dict, Optional, Self
 
 from structlog.stdlib import BoundLogger
 
@@ -34,13 +34,36 @@ class DockerCredentials:
         auth_data = f"{self.username}:{self.password}".encode()
         return base64.b64encode(auth_data).decode()
 
+    @classmethod
+    def from_config(cls, host: str, config: dict[str, str]) -> Self:
+        """Create from a Docker config entry (such as a pull secret).
+
+        This requires the ``auth`` field be set and ignores the ``username``
+        and ``password`` field.
+
+        Parameters
+        ----------
+        host
+            The hostname of the server for which these credentials apply.
+        config
+            The entry for that hostname in the configuration.
+
+        Returns
+        -------
+        DockerCredentials
+            The resulting credentials.
+        """
+        basic_auth = base64.b64decode(config["auth"].encode()).decode()
+        username, password = basic_auth.split(":", 1)
+        return cls(registry_host=host, username=username, password=password)
+
 
 class DockerCredentialsMap:
     def __init__(
         self, logger: BoundLogger, filename: str = DOCKER_SECRETS_PATH
     ) -> None:
         self.logger = logger
-        self._credentials: Dict[str, DockerCredentials] = dict()
+        self._creds: Dict[str, DockerCredentials] = dict()
         if filename == "":
             return
         try:
@@ -49,21 +72,16 @@ class DockerCredentialsMap:
             self.logger.warning(f"No credentials file at {filename}")
 
     def get(self, host: str) -> Optional[DockerCredentials]:
-        for h in self._credentials:
+        for h in self._creds:
             if h == host or host.endswith(f".{h}"):
-                return self._credentials[h]
+                return self._creds[h]
         return None
 
     def load_file(self, filename: str) -> None:
         with open(filename) as f:
             credstore = json.loads(f.read())
-        self._credentials = dict()
+        self._creds = {}
         self.logger.debug("Removed existing Docker credentials")
-        for host in credstore["auths"]:
-            b64auth = credstore["auths"][host]["auth"]
-            basic_auth = base64.b64decode(b64auth).decode()
-            username, password = basic_auth.split(":", 1)
-            self._credentials[host] = DockerCredentials(
-                registry_host=host, username=username, password=password
-            )
+        for host, config in credstore["auths"].items():
+            self._creds[host] = DockerCredentials.from_config(host, config)
             self.logger.debug(f"Added authentication for '{host}'")

--- a/src/jupyterlabcontroller/services/prepuller/docker.py
+++ b/src/jupyterlabcontroller/services/prepuller/docker.py
@@ -1,26 +1,83 @@
-"""This class will manage communication with the Docker repository in order
-to fetch tag information and determine which images are available from the
-repository.
+"""Docker client for image prepuller."""
 
-These are known as our remote images.
-"""
+import asyncio
 
+from structlog.stdlib import BoundLogger
 
+from ...models.tag import RSPTag, RSPTagList, TagMap
+from ...models.v1.prepuller_config import PrepullerConfiguration
 from ...storage.docker import DockerStorageClient
 from .state import PrepullerState
 
 
 class PrepullerDockerClient:
+    """Query Docker for available images.
+
+    Fetches tag information for a given repository from a Docker registry.
+    These are known as our remote images and are used to calculate which
+    images to prepull.
+    """
+
     def __init__(
         self,
         namespace: str,
         state: PrepullerState,
         docker_client: DockerStorageClient,
+        config: PrepullerConfiguration,
+        logger: BoundLogger,
     ) -> None:
-        self.logger = docker_client.logger
+        self.logger = logger
         self.state = state
         self.namespace = namespace
         self.docker_client = docker_client
+        self.config = config
+
+    async def get_tag_map(self) -> TagMap:
+        """Get a list of all available tags.
+
+        Query all the tags for a given repository to get their digests,
+        inflate the tag and digest pairs into RSPTag objects, and return a
+        structure with dicts indexed by tag and by digest.  This in turn will
+        let us easily compare what we have remotely and what we have locally,
+        because it doesn't matter what tag we pulled a given image by, but
+        whether we have an image with the proper digest already on a given
+        node.
+        """
+        # Get all the tags and digests from the Docker API.  This is much too
+        # aggressive in parallelism and also is doing too much work since we
+        # don't care about the digests for most tags.
+        tags = await self.docker_client.list_tags(
+            self.config.registry, self.config.repository
+        )
+        tasks = [
+            asyncio.create_task(
+                self.docker_client.get_image_digest(
+                    self.config.registry, self.config.repository, tag
+                )
+            )
+            for tag in tags
+        ]
+        digests = await asyncio.gather(*tasks)
+        digest_for_tag = dict(zip(tags, digests))
+
+        # Inflate each tag/digest pair into an RSPTag
+        rsp_tags = []
+        for tag, digest in digest_for_tag.items():
+            alias_tags = []
+            if tag == self.config.recommended_tag:
+                alias_tags = [self.config.recommended_tag]
+            rsp_tags.append(
+                RSPTag.from_tag(
+                    tag=tag,
+                    digest=digest,
+                    image_ref=f"{self.config.path}:{tag}",
+                    alias_tags=alias_tags,
+                )
+            )
+
+        # Put it into a RSPTagList, which will sort the tags and produce
+        # the map.
+        return RSPTagList(tags=rsp_tags).tag_map
 
     async def refresh_if_needed(self) -> None:
         if self.state.needs_docker_refresh:
@@ -28,7 +85,7 @@ class PrepullerDockerClient:
 
     async def refresh_state_from_docker_repo(self) -> None:
         self.logger.info("Querying docker repository for image tags.")
-        tag_map = await self.docker_client.get_tag_map()
+        tag_map = await self.get_tag_map()
         self.state.set_remote_images(tag_map)
         self.state.update_docker_check_time()
         self.logger.info("Docker repository query complete.")

--- a/src/jupyterlabcontroller/services/prepuller/executor.py
+++ b/src/jupyterlabcontroller/services/prepuller/executor.py
@@ -33,7 +33,6 @@ class PrepullerExecutor:
         logger: BoundLogger,
         config: PrepullerConfiguration,
         namespace: str,
-        recommended_tag: str,
     ) -> None:
         self.state = state
         self.tag_client = PrepullerTagClient(

--- a/src/jupyterlabcontroller/services/prepuller/executor.py
+++ b/src/jupyterlabcontroller/services/prepuller/executor.py
@@ -33,6 +33,7 @@ class PrepullerExecutor:
         logger: BoundLogger,
         config: PrepullerConfiguration,
         namespace: str,
+        recommended_tag: str,
     ) -> None:
         self.state = state
         self.tag_client = PrepullerTagClient(
@@ -47,7 +48,11 @@ class PrepullerExecutor:
             namespace=namespace,
         )
         self.docker_client = PrepullerDockerClient(
-            state=self.state, docker_client=docker_client, namespace=namespace
+            state=self.state,
+            docker_client=docker_client,
+            namespace=namespace,
+            config=config,
+            logger=logger,
         )
         self.logger = logger
         self.namespace = namespace

--- a/src/jupyterlabcontroller/storage/docker.py
+++ b/src/jupyterlabcontroller/storage/docker.py
@@ -32,7 +32,7 @@ class DockerCredentialStore:
             credentials_data = json.load(f)
         credentials = {}
         for host, config in credentials_data["auths"].items():
-            credentials[host] = DockerCredentials.from_config(host, config)
+            credentials[host] = DockerCredentials.from_config(config)
         return cls(credentials)
 
     def __init__(self, credentials: dict[str, DockerCredentials]) -> None:
@@ -62,6 +62,18 @@ class DockerCredentialStore:
             if host.endswith(f".{domain}"):
                 return credentials
         return None
+
+    def set(self, host: str, credentials: DockerCredentials) -> None:
+        """Set credentials for a given host.
+
+        Parameters
+        ----------
+        host
+            The Docker API host.
+        credentials
+            The credentials to use for that host.
+        """
+        self._credentials[host] = credentials
 
     def save(self, path: Path) -> None:
         """Save the credentials store in ``.dockerconfigjson`` format.

--- a/src/jupyterlabcontroller/storage/docker.py
+++ b/src/jupyterlabcontroller/storage/docker.py
@@ -1,14 +1,81 @@
-"""Docker v2 registry client, based on cachemachine's client."""
-import asyncio
-from typing import List, Optional, cast
+"""Client for the Docker v2 API."""
+
+import json
+from pathlib import Path
+from typing import Self
 
 from httpx import AsyncClient, Response
 from structlog.stdlib import BoundLogger
 
 from ..exceptions import DockerRegistryError
 from ..models.domain.docker import DockerCredentials
-from ..models.tag import RSPTag, RSPTagList, TagMap
-from ..util import extract_untagged_path_from_image_ref
+
+
+class DockerCredentialStore:
+    """Read and write the ``.dockerconfigjson`` syntax used by Kubernetes."""
+
+    @classmethod
+    def from_path(cls, path: Path) -> Self:
+        """Load credentials for Docker API hosts from a file.
+
+        Parameters
+        ----------
+        path
+            Path to file containing credentials.
+
+        Returns
+        -------
+        DockerCredentialStore
+            The resulting credential store.
+        """
+        with path.open("r") as f:
+            credentials_data = json.load(f)
+        credentials = {}
+        for host, config in credentials_data["auths"].items():
+            credentials[host] = DockerCredentials.from_config(host, config)
+        return cls(credentials)
+
+    def __init__(self, credentials: dict[str, DockerCredentials]) -> None:
+        self._credentials = credentials
+
+    def get(self, host: str) -> DockerCredentials | None:
+        """Get credentials for a given host.
+
+        These may be domain credentials, so if there is no exact match, return
+        the credentials for any parent domain found.
+
+        Parameters
+        ----------
+        host
+            Host to which to authenticate.
+
+        Returns
+        -------
+        jupyterlabcontroller.models.domain.docker.DockerCredentials or None
+            The corresponding credentials or `None` if there are no
+            credentials in the store for that host.
+        """
+        credentials = self._credentials.get(host)
+        if credentials:
+            return credentials
+        for domain, credentials in self._credentials.items():
+            if host.endswith(f".{domain}"):
+                return credentials
+        return None
+
+    def save(self, path: Path) -> None:
+        """Save the credentials store in ``.dockerconfigjson`` format.
+
+        Parameters
+        ----------
+        path
+            Path at which to save the credential store.
+        """
+        data = {
+            "auths": {h: c.to_config() for h, c in self._credentials.items()}
+        }
+        with path.open("w") as f:
+            json.dump(data, f)
 
 
 class DockerStorageClient:
@@ -16,187 +83,219 @@ class DockerStorageClient:
 
     Parameters
     ----------
-    host
-        Docker registry API host.
-    repository
-        Image repository to query (for example, ``lsstsqre/sciplat-lab``).
-    recommended_tag
-        The tag indicating the recommended image.
     http_client
         Client to use to make requests.
     logger
         Logger for log messages.
     credentials
-        Authentication credentials for the Docker API server.
+        Docker credential store to use for authentication.
     """
 
     def __init__(
         self,
         *,
-        host: str,
-        repository: str,
-        recommended_tag: str,
         http_client: AsyncClient,
         logger: BoundLogger,
-        credentials: Optional[DockerCredentials] = None,
+        credentials: DockerCredentialStore,
     ) -> None:
-        """Create a new Docker Client.
+        self._client = http_client
+        self._logger = logger
+        self._credentials = credentials
+        self._authorization: dict[str, str] = {}
+
+    async def list_tags(self, registry: str, repository: str) -> list[str]:
+        """List all the tags for a given registry and repository.
 
         Parameters
         ----------
+        registry
+            Hostname of Docker container registry.
+        repository
+            Repository of images (for example, ``lsstsqre/sciplat-lab``).
+
+        Returns
+        -------
+        list of str
+            All the tags found for that repository.
         """
-        self.host = host
-        self.repository = repository
-        self.http_client = http_client
-        self.logger = logger
-        self.headers = {
-            "Accept": "application/vnd.docker.distribution.manifest.v2+json"
-        }
-        self.credentials = credentials
-        self.recommended_tag = recommended_tag
-
-    @property
-    def ref(self) -> str:
-        return f"{self.host}{self.repository}"
-
-    async def list_tags(self, authenticate: bool = True) -> List[str]:
-        """List all the tags.
-
-        Lists all the tags for the repository this client is used with.
-
-        Parameters
-        ----------
-        authenticate: should we try and authenticate?  Used internally
-          for retrying after successful authentication.
-        """
-        url = f"https://{self.host}/v2/{self.repository}/tags/list"
-        r = await self.http_client.get(url, headers=self.headers)
-        if r.status_code == 200:
-            body = r.json()
-            return body["tags"]
-        elif r.status_code == 401 and authenticate:
-            await self._authenticate(r)
-            return await self.list_tags(authenticate=False)
-        else:
-            msg = f"Unknown error listing tags from <{url}>: {r}"
-            raise DockerRegistryError(msg)
+        url = f"https://{registry}/v2/{repository}/tags/list"
+        r = await self._client.get(url, headers=self._build_headers(registry))
+        if r.status_code == 401:
+            headers = await self._authenticate(registry, r)
+            r = await self._client.get(url, headers=headers)
+        try:
+            r.raise_for_status()
+            return r.json()["tags"]
+        except Exception as e:
+            msg = f"Error listing tags from <{url}>"
+            raise DockerRegistryError(msg) from e
 
     async def get_image_digest(
-        self, tag: str, authenticate: bool = True
+        self, registry: str, repository: str, tag: str
     ) -> str:
-        """Get the digest of a tag.
-
-        Get the digest associated with an image tag.
+        """Get the digest associated with an image tag.
 
         Parameters
         ----------
-        tag: the tag to inspect
-        authenticate: should we to authenticate?  Used internally for
-          retrying after successful authentication.
+        registry
+            Hostname of Docker container registry.
+        repository
+            Repository of images (for example, ``lsstsqre/sciplat-lab``).
+        tag
+            The tag to inspect.
 
-        Returns the digest as a string, such as "sha256:abcdef"
+        Returns
+        -------
+        str
+            The digest, such as ``sha256:abcdef``.
         """
-        url = f"https://{self.host}/v2/{self.repository}/manifests/{tag}"
-        r = await self.http_client.head(url, headers=self.headers)
-        if r.status_code == 200:
+        url = f"https://{registry}/v2/{repository}/manifests/{tag}"
+        r = await self._client.head(url, headers=self._build_headers(registry))
+        if r.status_code == 401:
+            headers = await self._authenticate(registry, r)
+            r = await self._client.head(url, headers=headers)
+        try:
+            r.raise_for_status()
             return r.headers["Docker-Content-Digest"]
-        elif r.status_code == 401 and authenticate:
-            await self._authenticate(r)
-            return await self.get_image_digest(tag, authenticate=False)
-        else:
-            msg = f"Unknown error retrieving digest from <{url}>: {r}"
+        except Exception as e:
+            msg = f"Error retrieving digest from <{url}>"
+            raise DockerRegistryError(msg) from e
+
+    async def _authenticate(
+        self, host: str, response: Response
+    ) -> dict[str, str]:
+        """Authenticate after getting an auth challenge.
+
+        Sets headers to use for subsequent requests.  The caller should then
+        retry the request.
+
+        Parameters
+        ----------
+        host
+            The host to which we're making the request, and the key to find
+            Docker credentials to use for authentication.
+        response
+            The response from the server that includes an auth challenge.
+
+        Returns
+        -------
+        dict of str to str
+            New headers to use for this host.
+
+        Raises
+        ------
+        DockerRegistryError
+            Some failure in talking to the Docker registry API server.
+        """
+        if host in self._authorization:
+            msg = f"Authentication credentials for {host} rejected"
             raise DockerRegistryError(msg)
 
-    async def _authenticate(self, response: Response) -> None:
-        """Internal method to authenticate after getting an auth challenge.
+        credentials = self._credentials.get(host)
+        if not credentials:
+            msg = f"No Docker API credentials available for {host}"
+            raise DockerRegistryError(msg)
 
-        Doesn't return anything but will set additional headers for future
-        requests.
-
-        Parameters
-        ----------
-        response: response that contains an auth challenge.
-        """
         challenge = response.headers.get("WWW-Authenticate")
         if not challenge:
-            raise DockerRegistryError("No authentication challenge")
-
-        (challenge_type, params) = challenge.split(" ", 1)
+            msg = f"Docker API 401 response from {host} contains no challenge"
+            raise DockerRegistryError(msg)
+        challenge_type, params = challenge.split(None, 1)
         challenge_type = challenge_type.lower()
 
-        if self.credentials is None:
-            raise DockerRegistryError(
-                "Cannot authenticate with no credentials"
-            )
-
         if challenge_type == "basic":
-            # Basic auth is used by the Nexus Docker Registry.
-            self.headers["Authorization"] = self.credentials.authorization
-            self.logger.info(
-                f"Authenticated with basic auth as {self.credentials.username}"
+            self._authorization[host] = credentials.authorization
+            self._logger.info(
+                "Authenticated to Docker API with basic auth",
+                registry=host,
+                username=credentials.username,
             )
         elif challenge_type == "bearer":
             # Bearer is used by Docker's official registry.
-            self.logger.debug(f"Parsing challenge params {params}")
-            parts = dict()
-            for p in params.split(","):
-                (k, v) = p.split("=")
-                parts[k] = v.replace('"', "")
-
-            url = parts["realm"]
-            auth = (self.credentials.username, self.credentials.password)
-
-            self.logger.info(
-                f"Obtaining bearer token for {self.credentials.username}"
+            token = await self._get_bearer_token(host, credentials, params)
+            self._authorization[host] = f"Bearer {token}"
+            self._logger.info(
+                "Authenticated to Docker API with bearer token",
+                registry=host,
+                username=credentials.username,
             )
-            r = await self.http_client.get(url, auth=auth, params=parts)
-            if r.status_code == 200:
-                body = r.json()
-                token = body["token"]
-                self.headers["Authorization"] = f"Bearer {token}"
-                self.logger.info("Authenticated with bearer token")
-            else:
-                msg = f"Error getting token from <{url}>: {r}"
-                raise DockerRegistryError(msg)
         else:
-            msg = f"Unknown authentication challenge {challenge}"
+            msg = f"Unknown authentication challenge type {challenge_type}"
             raise DockerRegistryError(msg)
 
-    async def get_tag_map(self) -> TagMap:
-        """This is the only actual repository function we directly perform
-        (since pulls are done by K8s).  We query all the tags for a given
-        repository to get their digests, inflate the tag and digest pairs
-        into RSPTag objects, and return a structure with dicts indexed by
-        tag and by digest.  This in turn will let us easily compare what
-        we have remotely and what we have locally, because it doesn't matter
-        what tag we pulled a given image by, but whether we have an image
-        with the proper digest already on a given node.
+        return self._build_headers(host)
+
+    def _build_headers(self, host: str) -> dict[str, str]:
+        """Construct the headers used for a query to a given host.
+
+        Adds the ``Authorization`` header if we have discovered that this host
+        requires authentication.
+
+        Parameters
+        ----------
+        host
+            Docker registry API host.
+
+        Returns
+        -------
+        dict of str to str
+            Headers to pass to this host.
         """
-        tags = await self.list_tags()
-        tasks: List[asyncio.Task] = list()
-        for tag in tags:
-            # We probably want to rate-limit this ourselves somehow
-            tasks.append(asyncio.create_task(self.get_image_digest(tag)))
-        digests = cast(
-            List[str], await asyncio.gather(*tasks)
-        )  # gather doesn't know it's all strings, but we do.
-        t_to_d = dict(zip(tags, digests))
-        rsp_tags: List[RSPTag] = list()
-        # Inflate each tag/digest pair into an RSPTag
-        untagged_ref = extract_untagged_path_from_image_ref(self.ref)
-        for tag in t_to_d:
-            alias_tags = []
-            if tag == self.recommended_tag:
-                alias_tags = [self.recommended_tag]
-            rsp_tags.append(
-                RSPTag.from_tag(
-                    tag=tag,
-                    digest=t_to_d[tag],
-                    image_ref=f"{untagged_ref}:{tag}",
-                    alias_tags=alias_tags,
-                )
-            )
-        # Put it into a RSPTagList, which will sort the tags and produce
-        # the map.
-        rsp_taglist = RSPTagList(tags=rsp_tags)
-        return rsp_taglist.tag_map
+        headers = {
+            "Accept": "application/vnd.docker.distribution.manifest.v2+json"
+        }
+        if host in self._authorization:
+            headers["Authorization"] = self._authorization[host]
+        return headers
+
+    async def _get_bearer_token(
+        self, host: str, credentials: DockerCredentials, challenge_params: str
+    ) -> str:
+        """Get a bearer token for subsequent API calls.
+
+        Parameters
+        ----------
+        host
+            The host to which we're authenticating.
+        credentials
+            Authentication credentials.
+        challenge_params
+            The parameters it sent in the ``WWW-Authenticate`` header.
+
+        Returns
+        -------
+        str
+            The bearer token to use for subsequent calls to that host.
+
+        Raises
+        ------
+        DockerRegistryError
+            Some failure in talking to the Docker registry API server.
+        """
+        # We need to reflect the challenge parameters back as query
+        # parameters when obtaining our bearer token.
+        self._logger.debug(
+            "Parsing Docker API bearer challenge", params=challenge_params
+        )
+        params = {}
+        for param in challenge_params.split(","):
+            key, value = param.split("=", 1)
+            params[key] = value.replace('"', "")
+
+        # This is hugely unsafe and needs some sort of sanity check.
+        url = params["realm"]
+
+        # Request a bearer token.
+        self._logger.info(
+            "Obtaining Docker API bearer token",
+            registry=host,
+            username=credentials.username,
+        )
+        auth = (credentials.username, credentials.password)
+        r = await self._client.get(url, auth=auth, params=params)
+        try:
+            r.raise_for_status()
+            return r.json()["token"]
+        except Exception as e:
+            msg = f"Error getting bearer token from <{url}>"
+            raise DockerRegistryError(msg) from e

--- a/src/jupyterlabcontroller/storage/gafaelfawr.py
+++ b/src/jupyterlabcontroller/storage/gafaelfawr.py
@@ -12,7 +12,7 @@ class GafaelfawrStorageClient:
         self, http_client: AsyncClient, config: Configuration
     ) -> None:
         self.http_client = http_client
-        self._api_url = f"{config.runtime.instance_url}/auth/api/v1"
+        self._api_url = f"{config.base_url}/auth/api/v1"
         self._cache: Dict[str, GafaelfawrCache] = dict()
 
     async def _fetch(self, endpoint: str, token: str) -> Any:

--- a/tests/configs/standard/input/config.yaml
+++ b/tests/configs/standard/input/config.yaml
@@ -235,8 +235,3 @@ images:
   numReleases: 1
   numWeeklies: 2
   numDailies: 3
-# -- Runtime config will be filled in on initialization
-runtime:
-  path: ""
-  namespace: ""
-  instanceUrl: ""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,7 +55,7 @@ def obj_factory(std_config_dir: Path) -> TestObjectFactory:
 
 @pytest.fixture(scope="session")
 def config(std_config_dir: Path) -> Configuration:
-    configuration_dependency.set_filename(str(std_config_dir / "config.yaml"))
+    configuration_dependency.set_path(std_config_dir / "config.yaml")
     return configuration_dependency.config
 
 
@@ -92,7 +92,7 @@ async def app(
     events are sent during test execution.
     """
     app = create_app(
-        config_dir=str(std_config_dir), context_dependency=context_dependency
+        config_dir=std_config_dir, context_dependency=context_dependency
     )
     async with LifespanManager(app):
         yield app

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,8 +55,15 @@ def obj_factory(std_config_dir: Path) -> TestObjectFactory:
 
 @pytest.fixture(scope="session")
 def config(std_config_dir: Path) -> Configuration:
+    """Construct configuration for tests.
+
+    Overwrites the path to Docker secrets in the global configuration object
+    to a value that's valid for all tests.
+    """
     configuration_dependency.set_path(std_config_dir / "config.yaml")
-    return configuration_dependency.config
+    config = configuration_dependency.config
+    config.docker_secrets_path = std_config_dir / "docker_config.json"
+    return config
 
 
 @pytest_asyncio.fixture(scope="session")
@@ -91,9 +98,7 @@ async def app(
     Wraps the application in a lifespan manager so that startup and shutdown
     events are sent during test execution.
     """
-    app = create_app(
-        config_dir=std_config_dir, context_dependency=context_dependency
-    )
+    app = create_app(context_dependency=context_dependency)
     async with LifespanManager(app):
         yield app
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,10 +104,7 @@ async def app_client(
     config: Configuration,
 ) -> AsyncIterator[AsyncClient]:
     """Return an ``httpx.AsyncClient`` configured to talk to the test app."""
-    async with AsyncClient(
-        app=app,
-        base_url=config.runtime.instance_url,
-    ) as client:
+    async with AsyncClient(app=app, base_url=config.base_url) as client:
         yield client
 
 

--- a/tests/storage/docker_test.py
+++ b/tests/storage/docker_test.py
@@ -9,6 +9,7 @@ import respx
 
 from jupyterlabcontroller.config import Configuration
 from jupyterlabcontroller.factory import Factory
+from jupyterlabcontroller.storage.docker import DockerCredentialStore
 
 from ..support.docker import mock_docker
 
@@ -19,20 +20,24 @@ async def test_api(
 ) -> None:
     tag_names = {"w_2021_21", "w_2021_22", "d_2021_06_14", "d_2021_06_15"}
     tags = {t: "sha256:" + os.urandom(32).hex() for t in tag_names}
-    docker_credentials = factory.get_docker_credentials()
-    credentials = docker_credentials.get(config.images.registry)
+    registry = config.images.registry
+    repository = config.images.repository
+    store = DockerCredentialStore.from_path(config.docker_secrets_path)
+    credentials = store.get(registry)
     assert credentials
     mock_docker(
         respx_mock,
-        host=config.images.registry,
-        repository=config.images.repository,
+        host=registry,
+        repository=repository,
         credentials=credentials,
         tags=tags,
     )
     docker = factory.create_docker_storage()
-    assert set(await docker.list_tags()) == tag_names
-    assert await docker.get_image_digest("w_2021_21") == tags["w_2021_21"]
-    assert await docker.get_image_digest("w_2021_22") == tags["w_2021_22"]
+    assert set(await docker.list_tags(registry, repository)) == tag_names
+    digest = await docker.get_image_digest(registry, repository, "w_2021_21")
+    assert digest == tags["w_2021_21"]
+    digest = await docker.get_image_digest(registry, repository, "w_2021_22")
+    assert digest == tags["w_2021_22"]
 
 
 @pytest.mark.asyncio
@@ -41,17 +46,20 @@ async def test_bearer_auth(
 ) -> None:
     assert config.images.docker
     tags = {"r23_0_4": "sha256:" + os.urandom(32).hex()}
-    docker_credentials = factory.get_docker_credentials()
-    credentials = docker_credentials.get(config.images.docker.registry)
+    registry = config.images.registry
+    repository = config.images.repository
+    store = DockerCredentialStore.from_path(config.docker_secrets_path)
+    credentials = store.get(registry)
     assert credentials
     mock_docker(
         respx_mock,
-        host=config.images.docker.registry,
-        repository=config.images.docker.repository,
+        host=registry,
+        repository=repository,
         credentials=credentials,
         tags=tags,
         require_bearer=True,
     )
     docker = factory.create_docker_storage()
-    assert await docker.list_tags() == ["r23_0_4"]
-    assert await docker.get_image_digest("r23_0_4") == tags["r23_0_4"]
+    assert await docker.list_tags(registry, repository) == ["r23_0_4"]
+    digest = await docker.get_image_digest(registry, repository, "r23_0_4")
+    assert digest == tags["r23_0_4"]

--- a/tests/storage/docker_test.py
+++ b/tests/storage/docker_test.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import base64
+import json
 import os
+from pathlib import Path
 
 import pytest
 import respx
 
 from jupyterlabcontroller.config import Configuration
 from jupyterlabcontroller.factory import Factory
+from jupyterlabcontroller.models.domain.docker import DockerCredentials
 from jupyterlabcontroller.storage.docker import DockerCredentialStore
 
 from ..support.docker import mock_docker
@@ -63,3 +67,39 @@ async def test_bearer_auth(
     assert await docker.list_tags(registry, repository) == ["r23_0_4"]
     digest = await docker.get_image_digest(registry, repository, "r23_0_4")
     assert digest == tags["r23_0_4"]
+
+
+def test_credential_store(tmp_path: Path) -> None:
+    store = DockerCredentialStore({})
+    assert store.get("example.com") is None
+    credentials = DockerCredentials(username="foo", password="blahblah")
+    store.set("example.com", credentials)
+    assert store.get("example.com") == credentials
+    assert store.get("foo.example.com") == credentials
+    assert store.get("example.org") is None
+    other_credentials = DockerCredentials(username="u", password="p")
+    store.set("example.org", other_credentials)
+
+    store_path = tmp_path / "credentials.json"
+    store.save(store_path)
+    with store_path.open("r") as f:
+        data = json.load(f)
+    assert data == {
+        "auths": {
+            "example.com": {
+                "username": "foo",
+                "password": "blahblah",
+                "auth": base64.b64encode(b"foo:blahblah").decode(),
+            },
+            "example.org": {
+                "username": "u",
+                "password": "p",
+                "auth": base64.b64encode(b"u:p").decode(),
+            },
+        }
+    }
+
+    store = DockerCredentialStore.from_path(store_path)
+    assert store.get("example.com") == credentials
+    assert store.get("foo.example.com") == credentials
+    assert store.get("example.org") == other_credentials

--- a/tests/support/mockdocker.py
+++ b/tests/support/mockdocker.py
@@ -12,11 +12,11 @@ class MockDockerStorageClient(DockerStorageClient):
         self._test_obj = test_obj
         self.recommended_tag = recommended_tag
 
-    async def list_tags(self, authenticate: bool = True) -> List[str]:
+    async def list_tags(self, registry: str, repository: str) -> List[str]:
         return sorted(list(self._test_obj.repocontents.by_tag.keys()))
 
     async def get_image_digest(
-        self, tag: str, authenticate: bool = True
+        self, registry: str, repository: str, tag: str
     ) -> str:
         default_hash: str = "sha256:abcd"
         tm = self._test_obj.repocontents
@@ -26,11 +26,6 @@ class MockDockerStorageClient(DockerStorageClient):
             if tag in [x.tag for x in tag_objs]:
                 return digest
         return default_hash
-
-    @property
-    def ref(self) -> str:
-        labspec = self._test_obj.labspecs[0].options.image
-        return labspec
 
 
 mock_docker_dependency = MockDockerStorageClient(test_obj=test_object_factory)


### PR DESCRIPTION
The runtime section of the `Configuration` object had various parameters that were determined during configuration load and then set after creating the object, which required awkward initialization that was then ignored. All of these parameters could be handled a different way:

- `instance_url` was really `base_url` and needed to be initialized from an environment variable, which allowed it to be a normal top-level configuration parameter as long as the top-level configuration was changed to inherit from `BaseSettings` so that it would check the environment.
- `namespace_prefix` could be initialized from a `default_factory` function and was therefore moved to the lab configuration, since that's where it's used. (It's also reused as the namespace for prepulling, but shouldn't be; this will be fixed later.)
- `path` was only used to decide where to load Docker credentials from, which was better handled by a top-level configuration parameter with a default matching the expected Kubernetes path that is overridden by the test suite.

To enable this change, and improve the storage and service separation, overhaul how Docker secrets are managed. Replace `DockerCredentialsMap` with a new `DockerCredentialStore` class that (for the future) supports setting new credentials and saving the credential store as well. Rework `DockerStorageClient` to support multiple repositories in the same object (which we will need if we eventually support prepulling multiple images), with the registry and repository passed as arguments to its methods. Rework how it handles authentication to avoid the confusing `authenticate` bool parameter to its methods, which was not really part of the external API.