### PR TITLE
DM-37933: Recognize unknown tags with a cycle

### DIFF
--- a/src/jupyterlabcontroller/models/domain/rsptag.py
+++ b/src/jupyterlabcontroller/models/domain/rsptag.py
@@ -50,6 +50,8 @@ _DAILY = r"d_(?P<year>\d+)_(?P<month>\d+)_(?P<day>\d+)"
 _EXPERIMENTAL = r"exp"
 # c0020.002
 _CYCLE = r"_c(?P<cycle>\d+)\.(?P<cbuild>\d+)"
+# c0020 (used for alias tags)
+_CYCLE_ONLY = r"_c(?P<cycle>\d+)"
 # _whatever_your_little_heart_desires
 _REST = r"_(?P<rest>.*)"
 
@@ -97,6 +99,8 @@ _TAG_REGEXES = [
     (RSPImageType.DAILY, re.compile(_DAILY + "$")),
     # exp_w_2021_05_13_nosudo
     (RSPImageType.EXPERIMENTAL, re.compile(_EXPERIMENTAL + _REST + "$")),
+    # recommended_c0029
+    (RSPImageType.UNKNOWN, re.compile(".*" + _CYCLE_ONLY + "$")),
 ]
 
 
@@ -194,6 +198,17 @@ class RSPImageTag:
         rest = data.get("rest")
         cycle = data.get("cycle")
         cbuild = data.get("cbuild")
+
+        # We can't do very much with unknown tags with a cycle, but we do want
+        # to capture the cycle so that they survive cycle filtering.
+        if image_type == RSPImageType.UNKNOWN:
+            return cls(
+                image_type=image_type,
+                version=None,
+                tag=tag,
+                cycle=int(cycle) if cycle else None,
+                display_name=tag,
+            )
 
         # Experimental tags are often exp_<legal-tag>, meaning that they are
         # an experimental build on top of another tag with additional

--- a/tests/models/domain/rsptag_test.py
+++ b/tests/models/domain/rsptag_test.py
@@ -188,6 +188,13 @@ def test_from_str() -> None:
             "version": None,
             "cycle": None,
         },
+        "recommended_c0027": {
+            "tag": "recommended_c0027",
+            "image_type": RSPImageType.UNKNOWN,
+            "display_name": "recommended_c0027",
+            "version": None,
+            "cycle": 27,
+        },
         "not_a_normal_format": {
             "tag": "not_a_normal_format",
             "image_type": RSPImageType.UNKNOWN,


### PR DESCRIPTION
On Telescope and Site deployments where it is vital to prevent spawning images from the wrong SAL cycle, alias tags like recommended also have a cycle appended. Recognize those tags sufficiently to capture the cycle so that they're not excluded by cycle filtering when constructing the image menu.