### PR TITLE
DM-37933: Add RSPImageTag constructor for alias tags

### DIFF
--- a/src/jupyterlabcontroller/models/domain/rsptag.py
+++ b/src/jupyterlabcontroller/models/domain/rsptag.py
@@ -129,6 +129,35 @@ class RSPImageTag:
     """Human-readable display name."""
 
     @classmethod
+    def alias(cls, tag: str) -> Self:
+        """Create an alias tag.
+
+        Parameters
+        ----------
+        tag
+            Name of the alias tag.
+
+        Returns
+        -------
+        RSPImageTag
+            The corresponding `RSPImageTag`.
+        """
+        if match := re.match("(?P<tag>.*)" + _CYCLE_ONLY + "$", tag):
+            cycle = int(match.group("cycle"))
+            display_name = match.group("tag").replace("_", " ").title()
+            display_name += f' (SAL Cycle {match.group("cycle")})'
+        else:
+            cycle = None
+            display_name = tag.replace("_", " ").title()
+        return cls(
+            tag=tag,
+            image_type=RSPImageType.ALIAS,
+            version=None,
+            cycle=cycle,
+            display_name=display_name,
+        )
+
+    @classmethod
     def from_str(cls, tag: str) -> Self:
         """Parse a tag into an `RSPImageTag`.
 

--- a/tests/models/domain/rsptag_test.py
+++ b/tests/models/domain/rsptag_test.py
@@ -41,6 +41,28 @@ def test_tag_ordering() -> None:
     assert exp_one < exp_two
 
 
+def test_alias() -> None:
+    """Test alias constructor for an RSPImageTag."""
+    tag = RSPImageTag.alias("recommended")
+    assert asdict(tag) == {
+        "tag": "recommended",
+        "image_type": RSPImageType.ALIAS,
+        "version": None,
+        "cycle": None,
+        "display_name": "Recommended",
+    }
+
+    # If there is a cycle, we should extract it.
+    tag = RSPImageTag.alias("latest_weekly_c0046")
+    assert asdict(tag) == {
+        "tag": "latest_weekly_c0046",
+        "image_type": RSPImageType.ALIAS,
+        "version": None,
+        "cycle": 46,
+        "display_name": "Latest Weekly (SAL Cycle 0046)",
+    }
+
+
 def test_from_str() -> None:
     """Parse tags into RSPImageTag objects."""
     test_cases = {


### PR DESCRIPTION
Add a new class method to create alias tags. Do a bit of parsing of the tag name to extract a cycle if present, ensuring that the tags won't be filtered out by a cycle restriction (and making the display name a bit nicer because we can).

This constructor will be used in an upcoming change.