### PR TITLE
DM-37933: Simplify create_app

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterator
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -12,6 +12,7 @@ import respx
 from asgi_lifespan import LifespanManager
 from fastapi import FastAPI
 from httpx import AsyncClient
+from safir.testing.kubernetes import MockKubernetesApi, patch_kubernetes
 
 from jupyterlabcontroller.config import Configuration
 from jupyterlabcontroller.dependencies.config import configuration_dependency
@@ -70,7 +71,9 @@ def config(std_config_dir: Path) -> Configuration:
 
 @pytest_asyncio.fixture
 async def process_context(
-    config: Configuration, obj_factory: TestObjectFactory
+    config: Configuration,
+    mock_kubernetes: MockKubernetesApi,
+    obj_factory: TestObjectFactory,
 ) -> ProcessContext:
     """Create a process context with mock clients."""
     k8s_client = Mock(spec=K8sStorageClient)
@@ -141,3 +144,8 @@ def mock_gafaelfawr(
 ) -> MockGafaelfawr:
     test_users = obj_factory.userinfos
     return register_mock_gafaelfawr(respx_mock, config.base_url, test_users)
+
+
+@pytest.fixture
+def mock_kubernetes() -> Iterator[MockKubernetesApi]:
+    yield from patch_kubernetes()


### PR DESCRIPTION
Ensure all tests run with a mocked Kubernetes API. This is not currently used, since we currently also mock the Kubernetes storage object, but it ensures that initialize_kubernetes doesn't fail if there is no Kubernetes configuration. This allows removal of a workaround in create_app.

Move the startup and shutdown handlers into create_app to make it more explicit that they're private to create_app. Update the docstring with the true reason why we're deferring app creation: we want to give the test suite a chance to replace the configuration first.
