### PR TITLE
DM-37933: Include build information when sorting tags

### DIFF
--- a/src/jupyterlabcontroller/models/domain/rsptag.py
+++ b/src/jupyterlabcontroller/models/domain/rsptag.py
@@ -363,8 +363,23 @@ class RSPImageTag:
             return NotImplemented
         if self.image_type != other.image_type:
             return NotImplemented
-        if self.version and other.version:
-            return self.version.compare(other.version)
-        if self.tag == other.tag:
+        if not (self.version and other.version):
+            if self.tag == other.tag:
+                return 0
+            return -1 if self.tag < other.tag else 1
+        rank = self.version.compare(other.version)
+        if rank != 0:
+            return rank
+
+        # semver ignores the build for sorting purposes, but we don't want to
+        # since we want newer cycles to sort ahead of older cycles (and newer
+        # cycle builds to sort above older cycle builds) in otherwise matching
+        # tags, and the cycle information is stored in the build.
+        if self.version.build == other.version.build:
             return 0
-        return -1 if self.tag < other.tag else 1
+        elif self.version.build and not other.version.build:
+            return 1
+        elif not self.version.build and other.version.build:
+            return -1
+        else:
+            return -1 if self.version.build < other.version.build else 1

--- a/tests/models/domain/rsptag_test.py
+++ b/tests/models/domain/rsptag_test.py
@@ -34,6 +34,14 @@ def test_tag_ordering() -> None:
     assert three != four
     assert three < four
 
+    five = RSPImageTag.from_str("d_2023_02_10_c0031.004")
+    assert four != five
+    assert four < five
+
+    six = RSPImageTag.from_str("d_2023_02_10_c0031.005")
+    assert five != six
+    assert five < six
+
     exp_one = RSPImageTag.from_str("exp_20230209")
     exp_two = RSPImageTag.from_str("exp_random")
     assert exp_one == exp_one


### PR DESCRIPTION
semver ignores the build component of the version when comparing versions, but that's where we put the cycle and cycle build information. We therefore don't want to ignore it because we want tags with a newer cycle or cycle build to sort after ones with an older cycle or cycle build for otherwise identical versions, and tags with a cycle to sort after ones without a cycle. This ensures that when presenting tags in reverse sorted order, ones with a newer cycle or cycle build will be shown first.