### PR TITLE
DM-37933: Add RSPImage abstract type and its collection

### DIFF
--- a/src/jupyterlabcontroller/models/domain/rspimage.py
+++ b/src/jupyterlabcontroller/models/domain/rspimage.py
@@ -1,0 +1,331 @@
+"""Abstract data types for handling RSP images."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterable, Iterator
+from dataclasses import asdict, dataclass, field
+from typing import Optional, Self
+
+from .rsptag import RSPImageTag, RSPImageType
+
+__all__ = [
+    "RSPImage",
+    "RSPImageCollection",
+]
+
+_ALIAS_TYPES = (RSPImageType.ALIAS, RSPImageType.UNKNOWN)
+"""Image types that may be aliases and can be resolved."""
+
+
+@dataclass
+class RSPImage(RSPImageTag):
+    """A tagged Rubin Science Platform image.
+
+    An `RSPImage` differs from a
+    `~jupyterlabcontroller.models.domain.rsptag.RSPImageTag` by having a
+    reference and digest, potentially additional alias tags, and possibly
+    information discovered from a Kubernetes cluster, such as the image size
+    and the list of nodes on which it is present.
+    """
+
+    registry: str
+    """Docker registry from which this image comes."""
+
+    repository: str
+    """Docker repository from which this image comes."""
+
+    digest: str
+    """Image digest for the image, including prefixes like ``sha256:``."""
+
+    size: Optional[int] = None
+    """Size of the image in bytes if known."""
+
+    aliases: set[str] = field(default_factory=set)
+    """Known aliases for this image."""
+
+    alias_target: Optional[str] = None
+    """The tag of the image for which this is an alias, if known."""
+
+    nodes: set[str] = field(default_factory=set)
+    """Names of nodes on which this image is present."""
+
+    @classmethod
+    def from_tag(
+        cls, *, registry: str, repository: str, tag: RSPImageTag, digest: str
+    ) -> Self:
+        """Construct an image from an existing tag.
+
+        Parameters
+        ----------
+        registry
+            Docker registry for this image.
+        repository
+            Docker repository for this image.
+        tag
+            Tag for this image.
+        digest
+            Digest for this image.
+
+        Returns
+        -------
+        RSPImage
+            Resulting image object.
+        """
+        return cls(
+            registry=registry,
+            repository=repository,
+            digest=digest,
+            **asdict(tag),
+        )
+
+    @property
+    def is_possible_alias(self) -> bool:
+        """Whether this tag could be an alias."""
+        return self.image_type in _ALIAS_TYPES
+
+    @property
+    def reference(self) -> str:
+        """Docker reference for this image."""
+        return f"{self.registry}/{self.repository}:{self.tag}"
+
+    @property
+    def reference_with_digest(self) -> str:
+        """Docker reference for this image, with the digest."""
+        return f"{self.registry}/{self.repository}:{self.tag}@{self.digest}"
+
+    def resolve_alias(self, target: RSPImage) -> None:
+        """Resolve an alias tag with information about its target.
+
+        If we discover the target tag of an alias tag, we can improve the
+        alias tag's display name and cycle information using the information
+        of the underlying tag. This normally happens when ingesting a set of
+        images, including alias images, into an `RSPImageCollection`.
+
+        If the tag was previously an unknown tag but we found another tag with
+        the same digest, assume it is an alias tag and upgrade it.
+
+        Parameters
+        ----------
+        target
+            Another tag with the same digest.
+
+        Raises
+        ------
+        ValueError
+            If this image has a type other than unknown or alias. (Ideally
+            this should be represented in the type system, but that code is
+            tedious and doesn't add much value.)
+        """
+        if not self.is_possible_alias:
+            raise ValueError("Can only resolve alias and unknown images")
+        self.image_type = RSPImageType.ALIAS
+        self.alias_target = target.tag
+        target.aliases.add(self.tag)
+        base_display_name = self.tag.replace("_", " ").title()
+        self.display_name = f"{base_display_name} ({target.display_name})"
+        self.cycle = target.cycle
+
+
+class RSPImageCollection:
+    """Provides operations on a collection of `RSPImage` objects.
+
+    Parameters
+    ----------
+    images
+        `RSPImage` objects to store.
+    """
+
+    def __init__(self, images: Iterable[RSPImage]) -> None:
+        self._by_digest: dict[str, RSPImage]
+        self._by_tag_name: dict[str, RSPImage]
+        self._by_type: defaultdict[RSPImageType, list[RSPImage]]
+
+        # Unresolved aliases by digest that are not in _by_digest.
+        self._unresolved_aliases: defaultdict[str, list[RSPImage]]
+
+        # Ingest all images.
+        self._replace_contents(images)
+
+    def add(self, image: RSPImage) -> None:
+        """Add an image to the collection.
+
+        Parameters
+        ----------
+        image
+            The image to add.
+        """
+        # If we're adding a non-alias image and we have unresolved aliases for
+        # its digest, just reindex the entire collection. We otherwise have to
+        # handle unknown images that are promoted to alias images and need to
+        # change their sort order, which is unnecessarily complex to handle as
+        # a special case.
+        if not image.is_possible_alias:
+            if image.digest in self._unresolved_aliases:
+                all_images = list(self.all_images())
+                all_images.append(image)
+                self._replace_contents(all_images)
+                return
+
+        # This is a compact version of the same logic as _replace_contents.
+        if image.is_possible_alias and image.digest in self._by_digest:
+            other = self._by_digest[image.digest]
+            if other.image_type in _ALIAS_TYPES:
+                self._unresolved_aliases[image.digest].append(image)
+            else:
+                image.resolve_alias(other)
+        else:
+            self._by_digest[image.digest] = image
+        self._by_tag_name[image.tag] = image
+        self._by_type[image.image_type].append(image)
+        self._by_type[image.image_type].sort(reverse=True)
+
+    def all_images(
+        self, hide_aliased: bool = False, hide_resolved_aliases: bool = False
+    ) -> Iterator[RSPImage]:
+        """All images in sorted order.
+
+        Parameters
+        ----------
+        hide_aliased
+            If `True`, hide images for which an alias image exists. This is
+            used for menu generation to suppress a duplicate entry for an
+            image that already appeared earlier in the menu under an alias.
+        hide_resolved_aliases
+            If `True`, hide images that are an alias for another image in the
+            collection (but keep alias images when we don't have the target).
+            This is used to suppress the alias images when reporting prepull
+            status, where the underlying images are more useful to report.
+
+        Returns
+        -------
+        list of RSPImage
+            Images sorted by their type and then in reverse by their version.
+        """
+        for image_type in RSPImageType:
+            for image in self._by_type[image_type]:
+                if hide_aliased and image.aliases:
+                    continue
+                if hide_resolved_aliases and image.alias_target:
+                    continue
+                yield image
+
+    def image_for_digest(self, digest: str) -> RSPImage | None:
+        """Find an image by digest.
+
+        Returns the non-alias image by preference, although if an alias image
+        has not been resolved with a target, we may return the unresolved
+        alias.
+
+        Returns
+        -------
+        RSPImage or None
+            The image for that digest if found, otherwise `None`.
+        """
+        return self._by_digest.get(digest)
+
+    def image_for_tag_name(self, tag: str) -> RSPImage | None:
+        """Find an image by tag name.
+
+        Returns
+        -------
+        RSPImage or None
+            The image with that tag name if found, otherwise `None`.
+        """
+        return self._by_tag_name.get(tag)
+
+    def latest(self, image_type: RSPImageType) -> RSPImage | None:
+        """Get the latest image of a given type.
+
+        Parameters
+        ----------
+        image_type
+            Image type to retrieve.
+
+        Returns
+        -------
+        RSPImage or None
+            Latest image of that type, if any.
+        """
+        images = self._by_type[image_type]
+        return images[0] if images else None
+
+    def subtract(self, other: RSPImageCollection) -> RSPImageCollection:
+        """Find the list of images in this collection missing from another.
+
+        This returns only one image per digest, preferring the non-alias
+        images, since the intended use is for determining what images to
+        prepull, and there's no need to prepull the same image more than once
+        under different names.
+
+        Parameters
+        ----------
+        other
+            The other collection, whose contents will be subtracted from this
+            one.
+
+        Returns
+        -------
+        RSPImageCollection
+            All images found in this collection that weren't in the other.
+            Images are considered matching only if their digests match.
+        """
+        candidates = dict(self._by_digest)
+        for image in other.all_images():
+            if image.digest in candidates:
+                del candidates[image.digest]
+        return RSPImageCollection(candidates.values())
+
+    def _replace_contents(self, images: Iterable[RSPImage]) -> None:
+        """Replace the contents of the collection with the provided images.
+
+        This is primarily used by the constructor, but may also be used to
+        reindex the entire collection if needed.
+
+        Parameters
+        ----------
+        images
+            All images in the collection. Existing images will be discarded.
+        """
+        self._by_digest = {}
+        self._by_tag_name = {}
+        self._by_type = defaultdict(list)
+        self._unresolved_aliases = defaultdict(list)
+
+        # First pass: store all images other than unresolved images by digest.
+        # If there is a conflict between two non-alias images, the last one
+        # wins.  (This is for no particular reason except that it's easy.)
+        unresolved = []
+        for image in images:
+            if image.is_possible_alias:
+                unresolved.append(image)
+            else:
+                self._by_digest[image.digest] = image
+
+        # Second pass: add the unresolved images now that any images they
+        # alias should have been found. This is when we discover the targets
+        # of alias images so that we can resolve them. Do not try to resolve
+        # one alias or unknown tag with another; that adds no value. Keep
+        # track of our unresolved aliases so that we can resolve them if their
+        # target is added later.
+        for image in unresolved:
+            if image.digest in self._by_digest:
+                other = self._by_digest[image.digest]
+                if other.is_possible_alias:
+                    self._unresolved_aliases[image.digest].append(image)
+                else:
+                    image.resolve_alias(other)
+            else:
+                self._unresolved_aliases[image.digest].append(image)
+                self._by_digest[image.digest] = image
+
+        # Now, all images have been resolved where possible. Take a second
+        # pass and register all images by name and type.
+        for image in images:
+            self._by_tag_name[image.tag] = image
+            self._by_type[image.image_type].append(image)
+
+        # Sort all of the images by reverse order so the newest are first.
+        # This allows all_images to return sorted order efficiently.
+        for image_list in self._by_type.values():
+            image_list.sort(reverse=True)

--- a/tests/models/domain/rspimage_test.py
+++ b/tests/models/domain/rspimage_test.py
@@ -1,0 +1,226 @@
+"""Tests of abstract data types for Docker image analysis."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import asdict
+from random import SystemRandom
+
+import pytest
+from semver import VersionInfo
+
+from jupyterlabcontroller.models.domain.rspimage import (
+    RSPImage,
+    RSPImageCollection,
+)
+from jupyterlabcontroller.models.domain.rsptag import RSPImageTag, RSPImageType
+
+
+def test_image() -> None:
+    """Test RSPImage class."""
+    image = RSPImage.from_tag(
+        registry="lighthouse.ceres",
+        repository="library/sketchbook",
+        tag=RSPImageTag.from_str("d_2077_10_23"),
+        digest="sha256:1234",
+    )
+    assert asdict(image) == {
+        "tag": "d_2077_10_23",
+        "image_type": RSPImageType.DAILY,
+        "display_name": "Daily 2077_10_23",
+        "version": VersionInfo(2077, 10, 23),
+        "cycle": None,
+        "registry": "lighthouse.ceres",
+        "repository": "library/sketchbook",
+        "digest": "sha256:1234",
+        "size": None,
+        "aliases": set(),
+        "alias_target": None,
+        "nodes": set(),
+    }
+    assert image.reference == (
+        "lighthouse.ceres/library/sketchbook:d_2077_10_23"
+    )
+    assert image.reference_with_digest == (
+        "lighthouse.ceres/library/sketchbook:d_2077_10_23@sha256:1234"
+    )
+    assert not image.is_possible_alias
+
+
+def test_resolve_alias() -> None:
+    """Test enhancing an RSPImage alias."""
+    image = RSPImage.from_tag(
+        registry="lighthouse.ceres",
+        repository="library/sketchbook",
+        tag=RSPImageTag.from_str("d_2077_10_23_c0045.003"),
+        digest="sha256:1234",
+    )
+    assert image.cycle == 45
+    recommended = RSPImage.from_tag(
+        registry="lighthouse.ceres",
+        repository="library/sketchbook",
+        tag=RSPImageTag.from_str("recommended"),
+        digest="sha256:1234",
+    )
+    assert recommended.image_type == RSPImageType.UNKNOWN
+    assert recommended.display_name == "recommended"
+    assert recommended.alias_target is None
+    assert recommended.cycle is None
+    assert recommended.is_possible_alias
+
+    recommended.resolve_alias(image)
+    assert recommended.image_type == RSPImageType.ALIAS
+    assert recommended.alias_target == "d_2077_10_23_c0045.003"
+    assert image.aliases == {"recommended"}
+    assert recommended.display_name == f"Recommended ({image.display_name})"
+    assert recommended.cycle == 45
+    assert recommended.is_possible_alias
+
+    # Can do the same thing with a tag that's already an alias.
+    latest_daily = RSPImage.from_tag(
+        registry="lighthouse.ceres",
+        repository="library/sketchbook",
+        tag=RSPImageTag.alias("latest_daily"),
+        digest="sha256:1234",
+    )
+    assert latest_daily.image_type == RSPImageType.ALIAS
+    assert latest_daily.display_name == "Latest Daily"
+
+    latest_daily.resolve_alias(image)
+    assert latest_daily.image_type == RSPImageType.ALIAS
+    assert latest_daily.alias_target == "d_2077_10_23_c0045.003"
+    assert image.aliases == {"recommended", "latest_daily"}
+    assert latest_daily.display_name == f"Latest Daily ({image.display_name})"
+
+    # Can't resolve some other image type.
+    with pytest.raises(ValueError):
+        image.resolve_alias(latest_daily)
+
+
+def make_test_image(tag: str) -> RSPImage:
+    """Create a test image from a tag with a random digest."""
+    return RSPImage.from_tag(
+        registry="lighthouse.ceres",
+        repository="library/sketchbook",
+        tag=RSPImageTag.from_str(tag),
+        digest="sha256:" + os.urandom(32).hex(),
+    )
+
+
+def test_collection() -> None:
+    """Test RSPImageCollection."""
+    tags = ["w_2077_46", "w_2077_45", "w_2077_44", "w_2077_43", "d_2077_10_21"]
+    images = [make_test_image(t) for t in tags]
+
+    # Add an alias image with the same digest as the first image.
+    recommended = RSPImage.from_tag(
+        registry="lighthouse.ceres",
+        repository="library/sketchbook",
+        tag=RSPImageTag.alias("recommended"),
+        digest=images[0].digest,
+    )
+    images.append(recommended)
+
+    # Add an unknown image with the same digest as the first image. This
+    # should get promoted to an alias.
+    latest_weekly = RSPImage.from_tag(
+        registry="lighthouse.ceres",
+        repository="library/sketchbook",
+        tag=RSPImageTag.from_str("latest_weekly"),
+        digest=images[0].digest,
+    )
+    assert latest_weekly.image_type == RSPImageType.UNKNOWN
+    images.append(latest_weekly)
+
+    # Ingest into a collection.
+    shuffled_images = list(images)
+    SystemRandom().shuffle(shuffled_images)
+    assert images[0].aliases == set()
+    collection = RSPImageCollection(shuffled_images)
+    assert latest_weekly.image_type == RSPImageType.ALIAS
+    assert latest_weekly.alias_target == "w_2077_46"
+    assert recommended.alias_target == "w_2077_46"
+    assert images[0].aliases == {"recommended", "latest_weekly"}
+
+    # Test asking for tags by name or the latest of a type.
+    assert collection.image_for_tag_name(images[0].tag) == images[0]
+    assert collection.image_for_tag_name("recommended") == recommended
+    assert collection.latest(RSPImageType.WEEKLY) == images[0]
+    assert collection.latest(RSPImageType.DAILY) == images[4]
+    assert collection.latest(RSPImageType.RELEASE) is None
+
+    # recommended and w_2077_46 have the same digest, but we should always
+    # return the latter rather than the alias when retrieving by digest.
+    assert collection.image_for_digest(images[0].digest) == images[0]
+
+    # Test all_images, its sorting, and its filtering options.
+    all_images = [i.tag for i in collection.all_images()]
+    assert all_images == ["recommended", "latest_weekly"] + tags
+    without_aliases = collection.all_images(hide_resolved_aliases=True)
+    assert [i.tag for i in without_aliases] == tags
+    assert [i.tag for i in collection.all_images(hide_aliased=True)] == [
+        "recommended",
+        "latest_weekly",
+        "w_2077_45",
+        "w_2077_44",
+        "w_2077_43",
+        "d_2077_10_21",
+    ]
+
+    # Test subtraction. Note that this only returns one image per digest and
+    # prefers the non-alias images.
+    other = RSPImageCollection(images[0:2])
+    remainder = collection.subtract(other)
+    assert [i.tag for i in remainder.all_images()] == [
+        "w_2077_44",
+        "w_2077_43",
+        "d_2077_10_21",
+    ]
+
+    # Test adding images. There is a special case here where we add an alias
+    # image and then later add its target, and want to switch which of them is
+    # the one retrieved by digest. We're setting up a test for that.
+    first = RSPImage.from_tag(
+        registry="lighthouse.ceres",
+        repository="library/sketchbook",
+        tag=RSPImageTag.from_str("recommended"),
+        digest="sha256:" + os.urandom(32).hex(),
+    )
+    collection = RSPImageCollection([first])
+    assert collection.image_for_digest(first.digest) == first
+    assert list(collection.all_images()) == [first]
+    assert list(collection.all_images(hide_resolved_aliases=True)) == [first]
+
+    # Now add another alias. This should not replace the first as the image to
+    # retrieve by digest, nor should it be enhanced.
+    second = RSPImage.from_tag(
+        registry="lighthouse.ceres",
+        repository="library/sketchbook",
+        tag=RSPImageTag.alias("latest_weekly"),
+        digest=first.digest,
+    )
+    assert second.alias_target is None
+    collection.add(second)
+    assert second.alias_target is None
+    assert collection.image_for_digest(first.digest) == first
+    assert list(collection.all_images()) == [second, first]
+    contents = list(collection.all_images(hide_resolved_aliases=True))
+    assert contents == [second, first]
+
+    # Finally, add the non-alias image with the same hash as both of these.
+    third = RSPImage.from_tag(
+        registry="lighthouse.ceres",
+        repository="library/sketchbook",
+        tag=RSPImageTag.from_str("w_2077_44"),
+        digest=first.digest,
+    )
+    collection.add(third)
+    assert first.alias_target == third.tag
+    assert second.alias_target == third.tag
+    assert third.aliases == {first.tag, second.tag}
+    assert collection.image_for_digest(first.digest) == third
+    assert list(collection.all_images(hide_resolved_aliases=True)) == [third]
+
+    # Note that first has been promoted to an alias and therefore changed its
+    # sort location.
+    assert list(collection.all_images()) == [first, second, third]


### PR DESCRIPTION
Continuing to lay the groundwork for a clearer expression of the complex image analysis algorithm, this introduces abstract data types for tracking images. An image is a tag annotated with its registry, repository, and digest, and is used to drive prepulling and to compare against when determining what images are cached.

As with RSPImageTagCollection, the operations on RSPImageCollection are chosen to satisfy the requirements of subsequent changes. This is where nearly all logic for alias handling, including resolving aliases to their underlying tags, is done.