### PR TITLE
DM-37933: Ensure all labs are spawned with a digest

### DIFF
--- a/src/jupyterlabcontroller/exceptions.py
+++ b/src/jupyterlabcontroller/exceptions.py
@@ -1,3 +1,9 @@
+class InvalidDockerReferenceError(Exception):
+    """Docker reference is not valid."""
+
+    pass
+
+
 class DockerRegistryError(Exception):
     """Unknown error working with the Docker registry."""
 

--- a/src/jupyterlabcontroller/factory.py
+++ b/src/jupyterlabcontroller/factory.py
@@ -244,6 +244,7 @@ class Factory:
             manager_namespace=self._context.config.lab.namespace_prefix,
             user_map=self._context.user_map,
             event_manager=self._context.event_manager,
+            image_service=self._context.image_service,
             logger=self._logger,
             lab_config=self._context.config.lab,
             k8s_client=self._context.k8s_client,

--- a/src/jupyterlabcontroller/models/domain/docker.py
+++ b/src/jupyterlabcontroller/models/domain/docker.py
@@ -1,8 +1,82 @@
 """Domain models for talking to the Docker API."""
 
+from __future__ import annotations
+
 import base64
+import re
 from dataclasses import dataclass
 from typing import Self
+
+__all__ = [
+    "DockerCredentials",
+    "DockerReference",
+]
+
+# Regex fragments used for Docker reference parsing.
+_REGISTRY = r"(?P<registry>[^/]+)"
+_REPOSITORY = r"/(?P<repository>[^:@]+)"
+_TAG = r"(?::(?P<tag>[^@]+))?"
+_DIGEST = r"(?:@(?P<digest>.+))?"
+
+# Regexes to parse the two recognized types of Docker references.
+_DIGEST_REGEX = re.compile(_REGISTRY + _REPOSITORY + _TAG + _DIGEST + "$")
+
+
+@dataclass
+class DockerReference:
+    """Parses a Docker reference."""
+
+    registry: str
+    """Registry (Docker API server) hosting the image."""
+
+    repository: str
+    """Repository of images (for example, ``lsstsqre/sciplat-lab``)."""
+
+    tag: str | None
+    """Tag, if present."""
+
+    digest: str | None
+    """Digest, if present."""
+
+    @classmethod
+    def from_str(cls, reference: str) -> Self:
+        """Parse a Docker reference string into its components.
+
+        Parameters
+        ----------
+        reference
+            Reference string.
+
+        Returns
+        -------
+        DockerReference
+            Resulting reference.
+
+        Raises
+        ------
+        ValueError
+            The reference could not be parsed. (Uses `ValueError` so that this
+            can be used as a Pydantic validator.)
+        """
+        match = _DIGEST_REGEX.match(reference)
+        if not match:
+            raise ValueError(f'Invalid Docker reference "{reference}"')
+        tag = match.group("tag")
+        digest = match.group("digest")
+        return cls(
+            registry=match.group("registry"),
+            repository=match.group("repository"),
+            tag=tag,
+            digest=digest,
+        )
+
+    def __str__(self) -> str:
+        result = f"{self.registry}/{self.repository}"
+        if self.tag is not None:
+            result += f":{self.tag}"
+        if self.digest is not None:
+            result += f"@{self.digest}"
+        return result
 
 
 @dataclass

--- a/src/jupyterlabcontroller/models/domain/rsptag.py
+++ b/src/jupyterlabcontroller/models/domain/rsptag.py
@@ -12,15 +12,15 @@ from typing import Optional, Self
 
 from semver import VersionInfo
 
+DOCKER_DEFAULT_TAG = "latest"
+"""Implicit tag used by Docker/Kubernetes when no tag is specified."""
+
 __all__ = [
     "DOCKER_DEFAULT_TAG",
     "RSPImageTag",
     "RSPImageTagCollection",
     "RSPImageType",
 ]
-
-DOCKER_DEFAULT_TAG = "latest"
-"""Implicit tag used by Docker/Kubernetes when no tag is specified."""
 
 
 class RSPImageType(Enum):

--- a/src/jupyterlabcontroller/storage/docker.py
+++ b/src/jupyterlabcontroller/storage/docker.py
@@ -165,6 +165,11 @@ class DockerStorageClient:
         -------
         str
             The digest, such as ``sha256:abcdef``.
+
+        Raises
+        ------
+        DockerRegistryError
+            Unable to retrieve the digest from the Docker Registry.
         """
         url = f"https://{registry}/v2/{repository}/manifests/{tag}"
         r = await self._client.head(url, headers=self._build_headers(registry))

--- a/tests/configs/standard/input/test_objects.json
+++ b/tests/configs/standard/input/test_objects.json
@@ -66,14 +66,14 @@
   ],
   "user_options": [
     {
-      "image": "lighthouse.ceres/library/sketchbook:latest_daily@sha256:1234",
+      "reference": "lighthouse.ceres/library/sketchbook:latest_daily@sha256:1234",
       "size": "small"
     }
   ],
   "lab_specification": [
     {
       "options": {
-	"image": "lighthouse.ceres/library/sketchbook:latest_daily@sha256:1234",
+	"reference": "lighthouse.ceres/library/sketchbook:latest_daily@sha256:1234",
 	"size": "small"
       },
       "env": {

--- a/tests/configs/standard/output/env.json
+++ b/tests/configs/standard/output/env.json
@@ -15,7 +15,7 @@
     "HOME": "/home/ceres",
     "HUB_ROUTE": "/nb/hub",
     "IMAGE_DESCRIPTION": "latest_daily",
-    "IMAGE_DIGEST": "1234",
+    "IMAGE_DIGEST": "sha256:1234",
     "JUPYTERHUB_ADMIN_ACCESS": "1",
     "JUPYTERHUB_API_URL": "http://hub.nublado2:8081/nb/hub/api",
     "JUPYTERHUB_BASE_URL": "/nb/",

--- a/tests/handlers/user_status_test.py
+++ b/tests/handlers/user_status_test.py
@@ -39,8 +39,8 @@ async def test_user_status(
         f"/nublado/spawner/v1/labs/{user.username}/create",
         json={
             "options": {
-                "image_list": [lab.options.image],
-                "image_dropdown": [lab.options.image],
+                "image_list": [lab.options.reference],
+                "image_dropdown": [lab.options.reference],
                 "size": [lab.options.size],
             },
             "env": lab.env,


### PR DESCRIPTION
The decision to not retrieve digests for all available images means that labs spawned from the dropdown menu may not have digests. However, we always want to record the digest of the image when spawning the pod for debugging purposes and better user display. The lab service also had some left-over reference and tag parsing code to reconstruct information about the image from the reference passed in via the lab creation form.

Correct this by adding a new method to the image service to create an RSPImage from a Docker reference, and then use the RSPImage as the source of data to encode in the pod environment ConfigMap. In the process, change image to reference in the lab options model and refactor reference parsing so that it can be shared between the lab service and cached image analysis.