### PR TITLE
DM-37933: Switch to full Kubernetes API mocking

### DIFF
--- a/src/jupyterlabcontroller/dependencies/context.py
+++ b/src/jupyterlabcontroller/dependencies/context.py
@@ -71,7 +71,6 @@ class ContextDependency:
 
     def __init__(self) -> None:
         self._process_context: Optional[ProcessContext] = None
-        self._overridden = False
 
     async def __call__(
         self,
@@ -103,13 +102,9 @@ class ContextDependency:
         config
             Configuration for the lab controller.
         """
-        if self._overriden:
-            if not self._process_context:
-                raise RuntimeError("Process context went missing")
-        else:
-            if self._process_context:
-                await self._process_context.stop()
-            self._process_context = await ProcessContext.from_config(config)
+        if self._process_context:
+            await self._process_context.stop()
+        self._process_context = await ProcessContext.from_config(config)
         await self._process_context.start()
 
         # This is an ugly hack to do an initial reconciliation of the user
@@ -127,22 +122,6 @@ class ContextDependency:
         if self._process_context:
             await self._process_context.stop()
         self._process_context = None
-
-    def override_process_context(
-        self, process_context: ProcessContext
-    ) -> None:
-        """Force use of the provided process context.
-
-        Only used by the test suite. If this method is called, `initialize`
-        will not recreate the process context.
-
-        Parameters
-        ----------
-        process_context
-            Process context to use for all requests.
-        """
-        self._overriden = True
-        self._process_context = process_context
 
 
 context_dependency = ContextDependency()

--- a/src/jupyterlabcontroller/services/lab.py
+++ b/src/jupyterlabcontroller/services/lab.py
@@ -105,12 +105,7 @@ class LabManager:
     async def completion_event(self, username: str) -> None:
         ev_queue = self.event_manager.get(username)
         cstr = f"Operation complete for {username}"
-        await ev_queue.asend(
-            Event(
-                data=cstr,
-                event=EventTypes.COMPLETE,
-            )
-        )
+        await ev_queue.asend(Event(data=cstr, event=EventTypes.COMPLETE))
         self.logger.info(cstr)
 
     async def failure_event(

--- a/tests/handlers/user_status_test.py
+++ b/tests/handlers/user_status_test.py
@@ -62,6 +62,7 @@ async def test_user_status(
         },
     )
     assert r.status_code == 200
+    expected_resources = size_manager.resources[LabSize(lab.options.size)]
     assert r.json() == {
         "env": lab.env,
         "events": [],
@@ -71,7 +72,7 @@ async def test_user_status(
         "namespaceQuota": None,
         "options": lab.options.dict(),
         "pod": "missing",
-        "resources": size_manager.resources[LabSize(lab.options.size)],
+        "resources": expected_resources.dict(),
         "status": "running",
         "uid": user.uid,
         "username": user.username,

--- a/tests/services/lab_test.py
+++ b/tests/services/lab_test.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from pathlib import Path
 from typing import Any
@@ -86,6 +87,10 @@ async def test_get_active_users(
     assert await factory.user_map.running() == [user.username]
 
     await lab_manager.delete_lab(user.username)
+
+    # We have to let the background task run and complete the namespace
+    # deletion.
+    await asyncio.sleep(0.2)
     assert await factory.user_map.running() == []
 
 

--- a/tests/support/kubernetes.py
+++ b/tests/support/kubernetes.py
@@ -1,0 +1,306 @@
+"""Mock for the Kubernetes API.
+
+This is a temporary derivative class and copy of a function from Safir to add
+additional support required to test the lab controller. Once this is fleshed
+out and confirmed working with lab controller tests, this functionality will
+be rolled back into Safir.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from collections import defaultdict
+from collections.abc import AsyncIterator, Iterator
+from datetime import timedelta
+from typing import Any, Optional
+from unittest.mock import AsyncMock, Mock, patch
+
+from kubernetes_asyncio import client, config
+from kubernetes_asyncio.client import (
+    ApiException,
+    CoreV1Event,
+    CoreV1EventList,
+    V1Namespace,
+    V1NamespaceList,
+    V1NetworkPolicy,
+    V1Node,
+    V1NodeList,
+    V1ObjectMeta,
+    V1ObjectReference,
+    V1Pod,
+    V1ResourceQuota,
+    V1Secret,
+    V1Service,
+)
+from safir.datetime import current_datetime
+from safir.testing.kubernetes import MockKubernetesApi
+
+__all__ = ["MockLabKubernetesApi", "patch_kubernetes"]
+
+
+class MockLabKubernetesApi(MockKubernetesApi):
+    """Mock Kubernetes API for testing."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.nodes: list[V1Node] = []
+        self.events: defaultdict[str, list[CoreV1Event]] = defaultdict(list)
+        self._new_events: defaultdict[str, asyncio.Event]
+        self._new_events = defaultdict(asyncio.Event)
+
+    def add_event_for_test(self, namespace: str, event: CoreV1Event) -> None:
+        """Add an event that will be returned by ``list_namespaced_event``."""
+        event.metadata.resource_version = str(len(self.events[namespace]))
+        self.events[namespace].append(event)
+        self._new_events[namespace].set()
+
+    def get_all_objects_in_namespace_for_test(
+        self, namespace: str
+    ) -> list[Any]:
+        """Returns all objects in the given namespace.
+
+        Note that due to how objects are stored in the mock, we can't
+        distinguish between a missing namespace and a namespace with no
+        objects. In both cases, the empty list is returned.
+
+        Parameters
+        ----------
+        namespace
+            Name of the namespace.
+
+        Returns
+        -------
+        list of Any
+            All objects found in that namespace, sorted by kind and then
+            name.
+        """
+        if namespace not in self.objects:
+            return []
+        result = []
+        for kind in sorted(self.objects[namespace].keys()):
+            for _, body in sorted(self.objects[namespace][kind].items()):
+                result.append(body)
+        return result
+
+    def set_nodes_for_test(self, nodes: list[V1Node]) -> None:
+        """Set the node structures that will be returned by `list_node`.
+
+        Parameters
+        ----------
+        nodes
+            New node list to return.
+        """
+        self.nodes = V1NodeList(items=nodes)
+
+    # EVENTS API
+
+    async def list_namespaced_event(
+        self,
+        namespace: str,
+        *,
+        field_selector: Optional[str] = None,
+        resource_version: str = "0",
+        timeout_seconds: Optional[int] = None,
+        watch: bool = False,
+        _preload_content: bool = True,
+        _request_timeout: Optional[int] = None,
+    ) -> CoreV1EventList:
+        self._maybe_error("list_namespaced_event", namespace)
+        if not watch:
+            return CoreV1EventList(items=self.events[namespace])
+
+        # All watches must not preload content since we're returning raw JSON.
+        # This is done by the Kubernetes API Watch object.
+        assert not _preload_content
+
+        # When the timeout has expired.
+        timeout = None
+        if timeout_seconds is not None:
+            timeout = current_datetime() + timedelta(seconds=timeout_seconds)
+
+        # Returns all available events for this namespace, and then waits for
+        # new events and returns them up to the timeout.
+        async def next_event() -> AsyncIterator[bytes]:
+            position = int(resource_version)
+            while True:
+                for event in self.events[namespace][position:]:
+                    raw = {"type": "ADDED", "object": event.to_dict()}
+                    yield json.dumps(raw).encode()
+                    position += 1
+                if timeout:
+                    now = current_datetime()
+                    timeout_left = (timeout - now).total_seconds()
+                    if timeout_left < 0:
+                        yield b""
+                        return
+                wait_event = self._new_events[namespace]
+                try:
+                    await asyncio.wait_for(wait_event.wait(), timeout_left)
+                except TimeoutError:
+                    yield b""
+                    return
+
+        event_generator = next_event()
+
+        async def readline() -> bytes:
+            return await event_generator.__anext__()
+
+        # To support the watch interface, we have to simulate a streaming
+        # aiohttp response. Thankfully, the watch only uses a minimal
+        # interface, so we can get away with a simple mock.
+        response = Mock()
+        response.content.readline = AsyncMock()
+        response.content.readline.side_effect = readline
+        return response
+
+    # NAMESPACE API
+
+    async def create_namespace(self, body: V1Namespace) -> None:
+        """Create a namespace.
+
+        The mock doesn't truly track namespaces since it autocreates them when
+        an object is created in that namespace (maybe that behavior should be
+        optional). All this method therefore does is detect conflicts.
+
+        Parameters
+        ----------
+        body
+            Namespace to create.
+        """
+        self._maybe_error("create_namespace", body)
+        if body.metadata.name in self.objects:
+            msg = f"Namespace {body.metadata.name} already exists"
+            raise ApiException(status=409, reason=msg)
+
+    async def delete_namespace(self, name: str) -> None:
+        self._maybe_error("delete_namespace")
+        if name not in self.objects:
+            raise ApiException(status=404, reason=f"{name} not found")
+        del self.objects[name]
+
+    async def read_namespace(self, name: str) -> V1Namespace:
+        self._maybe_error("read_namespace", name)
+        if name not in self.objects:
+            msg = f"Namespace {name} not found"
+            raise ApiException(status=404, reason=msg)
+        return V1Namespace(metadata=V1ObjectMeta(name=name))
+
+    async def list_namespace(self) -> V1NamespaceList:
+        self._maybe_error("list_namespace")
+        namespaces = []
+        for namespace in self.objects:
+            metadata = V1ObjectMeta(name=namespace)
+            namespaces.append(V1Namespace(metadata=metadata))
+        return V1NamespaceList(items=namespaces)
+
+    # NETWORKPOLICY API
+
+    async def create_namespaced_network_policy(
+        self, namespace: str, body: V1NetworkPolicy
+    ) -> None:
+        self._maybe_error("create_namespaced_network_policy", namespace, body)
+        name = body.metadata.name
+        if not body.metadata.namespace:
+            body.metadata.namespace = namespace
+        else:
+            assert namespace == body.metadata.namespace
+        self._store_object(namespace, "NetworkPolicy", name, body)
+
+    # NODE API
+
+    async def list_node(self) -> list[V1Node]:
+        self._maybe_error("list_node")
+        return self.nodes
+
+    # POD API
+
+    async def create_namespaced_pod(self, namespace: str, body: V1Pod) -> None:
+        await super().create_namespaced_pod(namespace, body)
+        event = CoreV1Event(
+            metadata=V1ObjectMeta(
+                name=f"{body.metadata.name}-start", namespace=namespace
+            ),
+            message=f"Pod {body.metadata.name} started",
+            involved_object=V1ObjectReference(
+                kind="Pod", name=body.metadata.name, namespace=namespace
+            ),
+        )
+        self.add_event_for_test(namespace, event)
+
+    async def read_namespaced_pod_status(
+        self, name: str, namespace: str
+    ) -> V1Pod:
+        self._maybe_error("read_namespaced_pod_status", name, namespace)
+
+        # Yes, this API actually returns a V1Pod. Presumably in the actual API
+        # only the status portion is populated, but it shouldn't matter for
+        # testing purposes.
+        return self._get_object(namespace, "Pod", name)
+
+    # RESOURCEQUOTA API
+
+    async def create_namespaced_resource_quota(
+        self, namespace: str, body: V1ResourceQuota
+    ) -> None:
+        self._maybe_error("create_namespaced_resource_quota", namespace, body)
+        name = body.metadata.name
+        if not body.metadata.namespace:
+            body.metadata.namespace = namespace
+        else:
+            assert namespace == body.metadata.namespace
+        self._store_object(namespace, "ResourceQuota", name, body)
+
+    # SECRETS API
+
+    async def create_namespaced_secret(
+        self, namespace: str, body: V1Secret
+    ) -> None:
+        # Safir used the wrong parameter name, so this fixes that until Safir
+        # can be fixed.
+        await super().create_namespaced_secret(namespace, body)
+
+    # SERVICE API
+
+    async def create_namespaced_service(
+        self, namespace: str, body: V1Service
+    ) -> None:
+        self._maybe_error("create_namespaced_service", namespace, body)
+        name = body.metadata.name
+        if not body.metadata.namespace:
+            body.metadata.namespace = namespace
+        else:
+            assert namespace == body.metadata.namespace
+        self._store_object(namespace, "Service", name, body)
+
+
+def patch_kubernetes() -> Iterator[MockLabKubernetesApi]:
+    """Replace the Kubernetes API with a mock class.
+
+    Copied from `safir.testing.kubernetes.patch_kubernetes` with no changes
+    except the type of the mock class. This is temporary until this support
+    has been merged back into Safir.
+
+    Returns
+    -------
+    MockLabKubernetesApi
+        The mock Kubernetes API object.
+    """
+    mock_api = MockLabKubernetesApi()
+    with patch.object(config, "load_incluster_config"):
+        patchers = []
+        for api in ("CoreV1Api", "CustomObjectsApi", "NetworkingV1Api"):
+            patcher = patch.object(client, api)
+            mock_class = patcher.start()
+            mock_class.return_value = mock_api
+            patchers.append(patcher)
+        mock_api_client = Mock(spec=client.ApiClient)
+        mock_api_client.close = AsyncMock()
+        with patch.object(client, "ApiClient") as mock_client:
+            mock_client.return_value = mock_api_client
+            os.environ["KUBERNETES_PORT"] = "tcp://10.0.0.1:443"
+            yield mock_api
+            del os.environ["KUBERNETES_PORT"]
+        for patcher in patchers:
+            patcher.stop()


### PR DESCRIPTION
Stop using the mock Kubernetes storage object in favor of a full mock of the Kubernetes API for the methods that the lab controller calls. This is temporarily implemented as a subclass of the mock class provided by Safir, but those changes will be rolled back into Safir once they have been thoroughly exercised.

This uncovered a timing problem with one lab service API test, where deletion was handled by a background task and therefore the user map didn't update immediately. Handle that with a delay that should be more than long enough for the background deletion to clean things up.

Remove some code from the Kubernetes storage layer that is handled by the Watch API. Setting _preload_content isn't an optimization; it tells the API to return the raw HTTP response rather than the deserialized object, and is always set internally by the Watch API (and should never be set otherwise). There is similarly no need to provide resource_version unless we're resuming a previous watch, since Watch handles setting it automatically.