### PR TITLE
DM-37933: Support bot user interface to lab creation

### DIFF
--- a/src/jupyterlabcontroller/constants.py
+++ b/src/jupyterlabcontroller/constants.py
@@ -25,3 +25,14 @@ LIMIT_TO_REQUEST_RATIO: float = 4.0  # Seems to work well so far.
 SPAWNER_FORM_TEMPLATE = (
     Path(__file__).parent / "assets" / "form_template.txt"
 ).read_text()
+
+# These must be kept in sync with Gafaelfawr until we can import the models
+# from Gafaelfawr directly.
+
+GROUPNAME_REGEX = "^[a-zA-Z][a-zA-Z0-9._-]*$"
+"""Regex matching all valid group names."""
+
+USERNAME_REGEX = (
+    "^[a-z0-9](?:[a-z0-9]|-[a-z0-9])*[a-z](?:[a-z0-9]|-[a-z0-9])*$"
+)
+"""Regex matching all valid usernames."""

--- a/src/jupyterlabcontroller/exceptions.py
+++ b/src/jupyterlabcontroller/exceptions.py
@@ -4,6 +4,12 @@ class InvalidDockerReferenceError(Exception):
     pass
 
 
+class UnknownDockerImageError(Exception):
+    """Cannot find a Docker image matching the requested parameters."""
+
+    pass
+
+
 class DockerRegistryError(Exception):
     """Unknown error working with the Docker registry."""
 

--- a/src/jupyterlabcontroller/handlers/labs.py
+++ b/src/jupyterlabcontroller/handlers/labs.py
@@ -10,7 +10,7 @@ from sse_starlette import EventSourceResponse
 
 from ..dependencies.context import RequestContext, context_dependency
 from ..exceptions import InvalidUserError, LabExistsError, NoUserMapError
-from ..models.v1.lab import LabSpecificationWireProtocol, UserData
+from ..models.v1.lab import LabSpecification, UserData
 
 
 def _external_url() -> str:
@@ -76,7 +76,7 @@ async def get_userdata(
 )
 async def post_new_lab(
     username: str,
-    lab: LabSpecificationWireProtocol,
+    lab: LabSpecification,
     x_auth_request_token: str = Header(...),
     context: RequestContext = Depends(context_dependency),
 ) -> str:
@@ -90,10 +90,9 @@ async def post_new_lab(
         raise HTTPException(status_code=403, detail="Forbidden")
 
     context.logger.debug(f"Received creation request for {username}")
-    lab_spec = lab.to_lab_specification()
     lab_manager = context.factory.create_lab_manager()
     try:
-        await lab_manager.create_lab(user, x_auth_request_token, lab_spec)
+        await lab_manager.create_lab(user, x_auth_request_token, lab)
     except LabExistsError:
         raise HTTPException(status_code=409, detail="Conflict")
     return f"{_external_url()}/nublado/spawner/v1/labs/{username}"

--- a/src/jupyterlabcontroller/services/lab.py
+++ b/src/jupyterlabcontroller/services/lab.py
@@ -190,8 +190,16 @@ class LabManager:
         """
         username = user.username
         namespace = self.namespace_from_user(user)
-        reference = DockerReference.from_str(lab.options.reference)
-        image = await self._image_service.image_for_reference(reference)
+        selection = lab.options.image_list or lab.options.image_dropdown
+        if selection:
+            reference = DockerReference.from_str(selection)
+            image = await self._image_service.image_for_reference(reference)
+        elif lab.options.image_class:
+            image_class = lab.options.image_class
+            image = self._image_service.image_for_class(image_class)
+        elif lab.options.image_tag:
+            tag = lab.options.image_tag
+            image = await self._image_service.image_for_tag_name(tag)
 
         # unclear if we should clear the event queue before this.  Probably not
         # because we don't want to wipe out the existing log, since we will
@@ -384,7 +392,7 @@ class LabManager:
         data = deepcopy(self.lab_config.env)
         # Get the stuff from the options form
         options = lab.options
-        if options.debug:
+        if options.enable_debug:
             data["DEBUG"] = "TRUE"
         if options.reset_user_env:
             data["RESET_USER_ENV"] = "TRUE"

--- a/tests/configs/standard/input/test_objects.json
+++ b/tests/configs/standard/input/test_objects.json
@@ -66,14 +66,14 @@
   ],
   "user_options": [
     {
-      "reference": "lighthouse.ceres/library/sketchbook:latest_daily@sha256:1234",
+      "image_list": "lighthouse.ceres/library/sketchbook:latest_daily@sha256:1234",
       "size": "small"
     }
   ],
   "lab_specification": [
     {
       "options": {
-	"reference": "lighthouse.ceres/library/sketchbook:latest_daily@sha256:1234",
+	"image_list": "lighthouse.ceres/library/sketchbook:latest_daily@sha256:1234",
 	"size": "small"
       },
       "env": {

--- a/tests/handlers/user_status_test.py
+++ b/tests/handlers/user_status_test.py
@@ -39,8 +39,7 @@ async def test_user_status(
         f"/nublado/spawner/v1/labs/{user.username}/create",
         json={
             "options": {
-                "image_list": [lab.options.reference],
-                "image_dropdown": [lab.options.reference],
+                "image_list": [lab.options.image_list],
                 "size": [lab.options.size],
             },
             "env": lab.env,
@@ -69,7 +68,7 @@ async def test_user_status(
         "gid": user.gid,
         "groups": user.dict()["groups"],
         "name": user.name,
-        "namespaceQuota": None,
+        "namespace_quota": None,
         "options": lab.options.dict(),
         "pod": "missing",
         "resources": expected_resources.dict(),

--- a/tests/services/lab_test.py
+++ b/tests/services/lab_test.py
@@ -123,9 +123,10 @@ async def test_env(
 ) -> None:
     token, user = obj_factory.get_user()
     lab = obj_factory.labspecs[0]
+    assert lab.options.image_list
     lab_manager = factory.create_lab_manager()
 
-    reference = DockerReference.from_str(lab.options.reference)
+    reference = DockerReference.from_str(lab.options.image_list)
     image = await factory.image_service.image_for_reference(reference)
     env = lab_manager.build_env(user=user, lab=lab, image=image, token=token)
     with (std_result_dir / "env.json").open("r") as f:
@@ -139,9 +140,10 @@ async def test_pod_spec(
 ) -> None:
     _, user = obj_factory.get_user()
     lab = obj_factory.labspecs[0]
+    assert lab.options.image_list
     lab_manager = factory.create_lab_manager()
 
-    reference = DockerReference.from_str(lab.options.reference)
+    reference = DockerReference.from_str(lab.options.image_list)
     image = await factory.image_service.image_for_reference(reference)
     pod_spec = lab_manager.build_pod_spec(user, image)
     with (std_result_dir / "pod.json").open("r") as f:


### PR DESCRIPTION
Implement the alternate interface to the /create route that allows services to select their image by ignoring the JupyterHub form and instead POSTing known values for image_tag or image_class, allowing them to bypass an API request to the lab controller to get the correct image reference to use.

Collapse the models for lab options into a single model and use validators to convert from the wire format resulting from the JupyterHub form post. This enlists Pydantic to do all the cleanup and validation for us and generate the correct 422 responses if needed, which simplifies the error handling and makes the models less complex and more consistent.

Update the username and group regexes from Gafaelfawr.