### PR TITLE
DM-38279: Fix handling of image selection in lab UserOptions

### DIFF
--- a/src/jupyterlabcontroller/models/v1/lab.py
+++ b/src/jupyterlabcontroller/models/v1/lab.py
@@ -178,6 +178,16 @@ class UserOptions(BaseModel):
         else:
             raise ValueError(f"Invalid boolean value {v}")
 
+    @validator("size", pre=True)
+    def _validate_size(cls, v: Any) -> Any:
+        """Lab sizes may be title-cased, so convert them to lowercase."""
+        if isinstance(v, LabSize):
+            return v
+        elif isinstance(v, str):
+            return v.lower()
+        else:
+            return v
+
 
 class UserResourceQuantum(BaseModel):
     cpu: float = Field(

--- a/src/jupyterlabcontroller/models/v1/lab.py
+++ b/src/jupyterlabcontroller/models/v1/lab.py
@@ -119,12 +119,6 @@ class UserOptions(BaseModel):
         title="Relocate user environment (`.cache`, `.jupyter`, `.local`)",
     )
 
-    class Config:
-        # Tell Pydantic's dict() method to convert the size enum to a string.
-        # This doesn't matter for FastAPI responses, since this is always done
-        # for JSON encoding, but it makes test suite construction easier.
-        use_enum_values = True
-
     @root_validator(pre=True)
     def _validate_lists(cls, values: dict[str, Any]) -> dict[str, list[Any]]:
         """Convert from lists of length 1 to values.
@@ -141,6 +135,8 @@ class UserOptions(BaseModel):
             if value is None:
                 continue
             if isinstance(value, list):
+                if not value:
+                    continue
                 if len(value) != 1:
                     raise ValueError(f"Too many values for {key}")
                 new_values[key] = value[0]
@@ -151,17 +147,22 @@ class UserOptions(BaseModel):
     @root_validator
     def _validate_one_image(cls, values: dict[str, Any]) -> dict[str, Any]:
         """Ensure that the image is only specified in one way."""
-        values_set = []
+        values_set = set()
         for k in ("image_list", "image_dropdown", "image_class", "image_tag"):
             if values.get(k) is not None:
                 if k == "image_list" and values[k] == DROPDOWN_SENTINEL_VALUE:
                     del values[k]
                     continue
-                values_set.append(k)
-        if len(values_set) < 1:
+                values_set.add(k)
+        if values_set == {"image_list", "image_dropdown"}:
+            # image_dropdown will have a spurious value if image_list is set,
+            # due to the form design, so in that case use image_list. (Unless
+            # it has the sentinel value, but that's handled above.)
+            del values["image_dropdown"]
+        elif len(values_set) < 1:
             raise ValueError("No image to spawn specified")
         elif len(values_set) > 1:
-            keys = ", ".join(values_set)
+            keys = ", ".join(sorted(values_set))
             raise ValueError(f"Image specified multiple ways ({keys})")
         return values
 

--- a/tests/models/v1/lab_test.py
+++ b/tests/models/v1/lab_test.py
@@ -1,0 +1,174 @@
+"""Tests for lab spawning models."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jupyterlabcontroller.constants import DROPDOWN_SENTINEL_VALUE
+from jupyterlabcontroller.models.v1.lab import ImageClass, LabSize, UserOptions
+
+
+def test_user_options() -> None:
+    """Test UserOptions, primarily all the ways to provide lab references."""
+    options = UserOptions.parse_obj(
+        {
+            "image_list": "lighthouse.ceres/library/sketchbook:latest_daily",
+            "size": "medium",
+        }
+    )
+    assert options.dict(exclude_none=True) == {
+        "image_list": "lighthouse.ceres/library/sketchbook:latest_daily",
+        "size": LabSize.MEDIUM,
+        "enable_debug": False,
+        "reset_user_env": False,
+    }
+
+    options = UserOptions.parse_obj(
+        {
+            "image_dropdown": [
+                "lighthouse.ceres/library/sketchbook:latest_daily"
+            ],
+            "size": ["small"],
+            "enable_debug": ["true"],
+        }
+    )
+    assert options.dict(exclude_none=True) == {
+        "image_dropdown": "lighthouse.ceres/library/sketchbook:latest_daily",
+        "size": LabSize.SMALL,
+        "enable_debug": True,
+        "reset_user_env": False,
+    }
+
+    # If the list is set to the sentinel value, it should be ignored.
+    options = UserOptions.parse_obj(
+        {
+            "image_list": [DROPDOWN_SENTINEL_VALUE],
+            "image_dropdown": [
+                "lighthouse.ceres/library/sketchbook:latest_daily"
+            ],
+            "size": ["large"],
+            "enable_debug": ["false"],
+            "reset_user_env": ["true"],
+        }
+    )
+    assert options.dict(exclude_none=True) == {
+        "image_dropdown": "lighthouse.ceres/library/sketchbook:latest_daily",
+        "size": LabSize.LARGE,
+        "enable_debug": False,
+        "reset_user_env": True,
+    }
+
+    # If both list and dropdown are set, list should be used by preference and
+    # dropdown ignored.
+    options = UserOptions.parse_obj(
+        {
+            "image_list": "lighthouse.ceres/library/sketchbook:w_2077_43",
+            "image_dropdown": [
+                "lighthouse.ceres/library/sketchbook:latest_daily"
+            ],
+            "size": "medium",
+        }
+    )
+    assert options.dict(exclude_none=True) == {
+        "image_list": "lighthouse.ceres/library/sketchbook:w_2077_43",
+        "size": LabSize.MEDIUM,
+        "enable_debug": False,
+        "reset_user_env": False,
+    }
+
+    # None and [] should be ignored, and DROPDOWN_SENTINEL_VALUE should still
+    # be ignored even if it's not in a list.
+    options = UserOptions.parse_obj(
+        {
+            "image_list": DROPDOWN_SENTINEL_VALUE,
+            "image_dropdown": [
+                "lighthouse.ceres/library/sketchbook:latest_daily"
+            ],
+            "image_class": None,
+            "image_tag": [],
+            "size": ["large"],
+            "enable_debug": ["false"],
+            "reset_user_env": ["true"],
+        }
+    )
+    assert options.dict(exclude_none=True) == {
+        "image_dropdown": "lighthouse.ceres/library/sketchbook:latest_daily",
+        "size": LabSize.LARGE,
+        "enable_debug": False,
+        "reset_user_env": True,
+    }
+
+    # Check image_class and image_tag.
+    options = UserOptions.parse_obj(
+        {"image_class": "recommended", "size": "large", "enable_debug": True}
+    )
+    assert options.dict(exclude_none=True) == {
+        "image_class": ImageClass.RECOMMENDED,
+        "size": LabSize.LARGE,
+        "enable_debug": True,
+        "reset_user_env": False,
+    }
+    options = UserOptions.parse_obj(
+        {"image_tag": "latest_daily", "size": LabSize.LARGE}
+    )
+    assert options.dict(exclude_none=True) == {
+        "image_tag": "latest_daily",
+        "size": LabSize.LARGE,
+        "enable_debug": False,
+        "reset_user_env": False,
+    }
+
+    # List of length longer than 1.
+    with pytest.raises(ValidationError):
+        UserOptions.parse_obj(
+            {
+                "image_list": [
+                    "lighthouse.ceres/library/sketchbook:w_2077_43",
+                    "lighthouse.ceres/library/sketchbook:latest_daily",
+                ],
+                "size": "medium",
+            }
+        )
+
+    # No images to spawn.
+    with pytest.raises(ValidationError):
+        UserOptions.parse_obj({"size": "medium"})
+
+    # Images provided in multiple ways.
+    with pytest.raises(ValidationError):
+        UserOptions.parse_obj(
+            {
+                "image_list": "lighthouse.ceres/library/sketchbook:w_2077_43",
+                "image_class": "recommended",
+                "size": "medium",
+            }
+        )
+    with pytest.raises(ValidationError):
+        UserOptions.parse_obj(
+            {
+                "image_dropdown": [
+                    "lighthouse.ceres/library/sketchbook:w_2077_43"
+                ],
+                "image_tag": "latest_weekly",
+                "size": "medium",
+            }
+        )
+    with pytest.raises(ValidationError):
+        UserOptions.parse_obj(
+            {
+                "image_class": "recommended",
+                "image_tag": "latest_weekly",
+                "size": "medium",
+            }
+        )
+
+    # Invalid boolean.
+    with pytest.raises(ValidationError):
+        UserOptions.parse_obj(
+            {
+                "image_tag": "latest_weekly",
+                "size": "medium",
+                "enable_debug": "on",
+            }
+        )

--- a/tests/models/v1/lab_test.py
+++ b/tests/models/v1/lab_test.py
@@ -67,7 +67,7 @@ def test_user_options() -> None:
             "image_dropdown": [
                 "lighthouse.ceres/library/sketchbook:latest_daily"
             ],
-            "size": "medium",
+            "size": LabSize.MEDIUM,
         }
     )
     assert options.dict(exclude_none=True) == {
@@ -89,7 +89,7 @@ def test_user_options() -> None:
             "image_tag": [],
             "size": ["large"],
             "enable_debug": ["false"],
-            "reset_user_env": ["true"],
+            "reset_user_env": "true",
         }
     )
     assert options.dict(exclude_none=True) == {
@@ -99,9 +99,9 @@ def test_user_options() -> None:
         "reset_user_env": True,
     }
 
-    # Check image_class and image_tag.
+    # Check image_class and image_tag, and also check title-cased sizes.
     options = UserOptions.parse_obj(
-        {"image_class": "recommended", "size": "large", "enable_debug": True}
+        {"image_class": "recommended", "size": "Large", "enable_debug": True}
     )
     assert options.dict(exclude_none=True) == {
         "image_class": ImageClass.RECOMMENDED,
@@ -110,7 +110,7 @@ def test_user_options() -> None:
         "reset_user_env": False,
     }
     options = UserOptions.parse_obj(
-        {"image_tag": "latest_daily", "size": LabSize.LARGE}
+        {"image_tag": "latest_daily", "size": ["Large"]}
     )
     assert options.dict(exclude_none=True) == {
         "image_tag": "latest_daily",


### PR DESCRIPTION
Treat empty lists in UserOptions input equivalent to None. Add a test for UserOptions to ensure that DROPDOWN_SENTINEL_VALUE is handled correctly, lists are converted to regular elements, and booleans are converted correctly.

If both image_list and image_dropdown are set (but only those two), use image_list and ignore image_dropdown. Due to how our form is designed, image_dropdown will always be set, but if image_list is not the sentinel value, it should override.

Stop configuring UserOptions with use_enum_values. This was an attempt to put strings into the dict() output for easier testing, but the test suite has been refactored to not need this, and this put the string directly into the model attribute as well, breaking other parts of the code.