### PR TITLE
DM-38279: Wait for lab deletion before returning

### DIFF
--- a/src/jupyterlabcontroller/handlers/labs.py
+++ b/src/jupyterlabcontroller/handlers/labs.py
@@ -105,7 +105,7 @@ async def post_new_lab(
         404: {"description": "Lab not found", "model": ErrorModel},
         403: {"description": "Forbidden", "model": ErrorModel},
     },
-    status_code=202,
+    status_code=204,
 )
 async def delete_user_lab(
     username: str,

--- a/src/jupyterlabcontroller/services/lab.py
+++ b/src/jupyterlabcontroller/services/lab.py
@@ -801,19 +801,15 @@ class LabManager:
             await self.k8s_client.delete_namespace(
                 self.namespace_from_user(user)
             )
+            await self.await_ns_deletion(
+                namespace=self.namespace_from_user(user),
+                username=user.username,
+            )
         except Exception as e:
             emsg = f"Could not delete lab environment: '{e}'"
             await self.failure_event(username, emsg)
             user.status = LabStatus.FAILED
             raise
-        ns_task = create_task(
-            self.await_ns_deletion(
-                namespace=self.namespace_from_user(user),
-                username=user.username,
-            )
-        )
-        self._tasks.add(ns_task)
-        ns_task.add_done_callback(self._tasks.discard)
 
     async def reconcile_user_map(self) -> None:
         self.logger.debug("Reconciling user map with observed state.")

--- a/tests/services/lab_test.py
+++ b/tests/services/lab_test.py
@@ -64,8 +64,6 @@ async def test_lab_manager(
     assert lab_manager.check_for_user(user.username)
 
     await lab_manager.delete_lab(user.username)
-    namespace = lab_manager.namespace_from_user(user)
-    await lab_manager.await_ns_deletion(namespace, user.username)
     assert not lab_manager.check_for_user(user.username)
 
 


### PR DESCRIPTION
If we wait for namespace deletion in the background and return immediately to JupyterHub, JupyterHub assumes that we have deleted the lab and may immediately attempt to create a new one, which then fails.