### PR TITLE
DM-38279: Fix quota handling

### DIFF
--- a/src/jupyterlabcontroller/factory.py
+++ b/src/jupyterlabcontroller/factory.py
@@ -21,6 +21,7 @@ from .services.form import FormManager
 from .services.image import ImageService
 from .services.lab import LabManager
 from .services.prepuller import Prepuller
+from .services.size import SizeManager
 from .storage.docker import DockerStorageClient
 from .storage.gafaelfawr import GafaelfawrStorageClient
 from .storage.k8s import K8sStorageClient
@@ -224,16 +225,21 @@ class Factory:
         )
 
     def create_lab_manager(self) -> LabManager:
+        size_manager = self.create_size_manager()
         return LabManager(
             instance_url=self._context.config.base_url,
             manager_namespace=self._context.config.lab.namespace_prefix,
             user_map=self._context.user_map,
             event_manager=self._context.event_manager,
             image_service=self._context.image_service,
+            size_manager=size_manager,
             logger=self._logger,
             lab_config=self._context.config.lab,
             k8s_client=self._context.k8s_client,
         )
+
+    def create_size_manager(self) -> SizeManager:
+        return SizeManager(self._context.config.lab.sizes)
 
     def set_logger(self, logger: BoundLogger) -> None:
         """Replace the internal logger.

--- a/src/jupyterlabcontroller/services/lab.py
+++ b/src/jupyterlabcontroller/services/lab.py
@@ -22,6 +22,7 @@ from kubernetes_asyncio.client.models import (
     V1PodSecurityContext,
     V1PodSpec,
     V1ResourceFieldSelector,
+    V1ResourceRequirements,
     V1SecretVolumeSource,
     V1SecurityContext,
     V1Volume,
@@ -37,7 +38,6 @@ from ..models.domain.rspimage import RSPImage
 from ..models.domain.usermap import UserMap
 from ..models.v1.event import Event, EventTypes
 from ..models.v1.lab import (
-    LabSize,
     LabSpecification,
     LabStatus,
     UserData,
@@ -63,6 +63,7 @@ class LabManager:
         instance_url: str,
         user_map: UserMap,
         event_manager: EventManager,
+        size_manager: SizeManager,
         image_service: ImageService,
         logger: BoundLogger,
         lab_config: LabConfiguration,
@@ -72,6 +73,7 @@ class LabManager:
         self.instance_url = instance_url
         self.user_map = user_map
         self.event_manager = event_manager
+        self._size_manager = size_manager
         self._image_service = image_service
         self.logger = logger
         self.lab_config = lab_config
@@ -81,10 +83,6 @@ class LabManager:
     def namespace_from_user(self, user: UserInfo) -> str:
         """Exposed because the unit tests use it."""
         return f"{self.manager_namespace}-{user.username}"
-
-    def get_resources(self, lab: LabSpecification) -> UserResources:
-        size_manager = SizeManager(self.lab_config.sizes)
-        return size_manager.resources[LabSize(lab.options.size)]
 
     def check_for_user(self, username: str) -> bool:
         """True if there's a lab for the user, otherwise false."""
@@ -214,7 +212,7 @@ class LabManager:
             UserData.new_from_user_resources(
                 user=user,
                 labspec=lab,
-                resources=self.get_resources(lab),
+                resources=self._size_manager.resources(lab.options.size),
             ),
         )
         #
@@ -234,7 +232,8 @@ class LabManager:
             user=user, lab=lab, image=image, token=token
         )
         await self.info_event(username, "Resource objects created", 40)
-        await self.create_user_pod(user, image)
+        resources = self._size_manager.resources(lab.options.size)
+        await self.create_user_pod(user, resources, image)
         self.user_map.set_status(username, status=LabStatus.PENDING)
         # We need to set the expected internal URL, because the spawner
         # start needs to know it, even though it's not accessible yet.
@@ -405,7 +404,7 @@ class LabManager:
             data["DEBUG"] = "TRUE"
         if options.reset_user_env:
             data["RESET_USER_ENV"] = "TRUE"
-        resources = self.get_resources(lab=lab)
+        resources = self._size_manager.resources(lab.options.size)
         #
         # More of these, eventually, will come from the options form.
         #
@@ -473,8 +472,10 @@ class LabManager:
         else:
             return None
 
-    async def create_user_pod(self, user: UserInfo, image: RSPImage) -> None:
-        pod = self.build_pod_spec(user, image)
+    async def create_user_pod(
+        self, user: UserInfo, resources: UserResources, image: RSPImage
+    ) -> None:
+        pod = self.build_pod_spec(user, resources, image)
         snames = [x.secret_name for x in self.lab_config.secrets]
         needs_pull_secret = False
         if "pull-secret" in snames:
@@ -686,27 +687,29 @@ class LabManager:
         vols.append(runtime_vol)
         return vols
 
-    def build_init_ctrs(self, username: str) -> List[V1Container]:
+    def build_init_ctrs(
+        self, username: str, resources: UserResources
+    ) -> List[V1Container]:
         init_ctrs: List[V1Container] = []
         ic_volumes: List[LabVolumeContainer] = []
         for ic in self.lab_config.init_containers:
             if ic.volumes is not None:
                 ic_volumes = self.build_lab_config_volumes(ic.volumes)
             ic_vol_mounts = [x.volume_mount for x in ic_volumes]
-            ic_sec_ctx = (
-                V1SecurityContext(
-                    run_as_non_root=True,
-                    run_as_user=1000,
-                    allow_privilege_escalation=False,
-                ),
-            )
             if ic.privileged:
                 ic_sec_ctx = V1SecurityContext(
                     run_as_non_root=False,
                     run_as_user=0,
                     allow_privilege_escalation=True,
                 )
+            else:
+                ic_sec_ctx = V1SecurityContext(
+                    run_as_non_root=True,
+                    run_as_user=1000,
+                    allow_privilege_escalation=False,
+                )
             ctr = V1Container(
+                name=ic.name,
                 # We use the same environment as the notebook, because it
                 # includes things we need for provisioning.
                 env_from=[
@@ -716,8 +719,13 @@ class LabManager:
                         )
                     ),
                 ],
-                name=ic.name,
                 image=ic.image,
+                resources=V1ResourceRequirements(
+                    limits={
+                        "cpu": str(resources.limits.cpu),
+                        "memory": str(resources.limits.memory),
+                    }
+                ),
                 security_context=ic_sec_ctx,
                 volume_mounts=ic_vol_mounts,
             )
@@ -725,12 +733,14 @@ class LabManager:
             init_ctrs.append(ctr)
         return init_ctrs
 
-    def build_pod_spec(self, user: UserInfo, image: RSPImage) -> V1PodSpec:
+    def build_pod_spec(
+        self, user: UserInfo, resources: UserResources, image: RSPImage
+    ) -> V1PodSpec:
         username = user.username
         vol_recs = self.build_volumes(username=username)
         volumes = [x.volume for x in vol_recs]
         vol_mounts = [x.volume_mount for x in vol_recs]
-        init_ctrs = self.build_init_ctrs(username)
+        init_ctrs = self.build_init_ctrs(username, resources)
         env = [
             # Because spec.nodeName is not reflected in
             # DownwardAPIVolumeSource:
@@ -761,6 +771,16 @@ class LabManager:
                     name="jupyterlab",
                 ),
             ],
+            resources=V1ResourceRequirements(
+                limits={
+                    "cpu": str(resources.limits.cpu),
+                    "memory": str(resources.limits.memory),
+                },
+                requests={
+                    "cpu": str(resources.requests.cpu),
+                    "memory": str(resources.requests.memory),
+                },
+            ),
             security_context=V1SecurityContext(
                 run_as_non_root=True,
                 run_as_user=user.uid,

--- a/src/jupyterlabcontroller/services/lab.py
+++ b/src/jupyterlabcontroller/services/lab.py
@@ -724,7 +724,11 @@ class LabManager:
                     limits={
                         "cpu": str(resources.limits.cpu),
                         "memory": str(resources.limits.memory),
-                    }
+                    },
+                    requests={
+                        "cpu": str(resources.requests.cpu),
+                        "memory": str(resources.requests.memory),
+                    },
                 ),
                 security_context=ic_sec_ctx,
                 volume_mounts=ic_vol_mounts,

--- a/src/jupyterlabcontroller/services/size.py
+++ b/src/jupyterlabcontroller/services/size.py
@@ -1,7 +1,7 @@
 """Image size service.  It takes the set of lab sizes from the config
 in its constructor."""
 
-from typing import Dict, List
+from typing import List
 
 import bitmath
 
@@ -21,23 +21,6 @@ class SizeManager:
     def __init__(self, sizes: LabSizeDefinitions) -> None:
         self._sizes = sizes
 
-    @property
-    def resources(self) -> Dict[LabSize, UserResources]:
-        r: Dict[LabSize, UserResources] = dict()
-        for sz in self._sizes:
-            cpu = self._sizes[sz].cpu
-            memfld = self._sizes[sz].memory
-            mem = memory_string_to_int(memfld)
-            r[LabSize(sz)] = UserResources(
-                requests=UserResourceQuantum(
-                    cpu=cpu / LIMIT_TO_REQUEST_RATIO,
-                    memory=int(mem / LIMIT_TO_REQUEST_RATIO),
-                ),
-                limits=UserResourceQuantum(cpu=cpu, memory=mem),
-            )
-        return r
-
-    @property
     def formdata(self) -> List[FormSize]:
         """Return the text representation of our sizes in a format suitable
         for injecting into the user spawner form"""
@@ -49,3 +32,14 @@ class SizeManager:
             )
             for x in self._sizes
         ]
+
+    def resources(self, size: LabSize) -> UserResources:
+        cpu = self._sizes[size].cpu
+        memory = memory_string_to_int(self._sizes[size].memory)
+        return UserResources(
+            limits=UserResourceQuantum(cpu=cpu, memory=memory),
+            requests=UserResourceQuantum(
+                cpu=cpu / LIMIT_TO_REQUEST_RATIO,
+                memory=int(memory / LIMIT_TO_REQUEST_RATIO),
+            ),
+        )

--- a/src/jupyterlabcontroller/storage/k8s.py
+++ b/src/jupyterlabcontroller/storage/k8s.py
@@ -475,10 +475,8 @@ class K8sStorageClient:
             metadata=self.get_std_metadata(name, namespace=namespace),
             spec=V1ResourceQuotaSpec(
                 hard={
-                    "limits": {
-                        "cpu": str(quota.cpu),
-                        "memory": str(quota.memory),
-                    },
+                    "limits.cpu": str(quota.cpu),
+                    "limits.memory": str(quota.memory),
                 }
             ),
         )

--- a/tests/configs/standard/output/pod.json
+++ b/tests/configs/standard/output/pod.json
@@ -30,6 +30,16 @@
           "name": "jupyterlab"
         }
       ],
+      "resources": {
+        "limits": {
+          "cpu": "1.0",
+          "memory": "3221225472"
+        },
+        "requests": {
+          "cpu": "0.25",
+          "memory": "805306368"
+        }
+      },
       "security_context": {
 	"run_as_group": 1101,
         "run_as_non_root": true,

--- a/tests/handlers/user_status_test.py
+++ b/tests/handlers/user_status_test.py
@@ -6,7 +6,6 @@ import pytest
 from httpx import AsyncClient
 
 from jupyterlabcontroller.config import Configuration
-from jupyterlabcontroller.models.v1.lab import LabSize
 from jupyterlabcontroller.services.size import SizeManager
 
 from ..settings import TestObjectFactory
@@ -60,7 +59,7 @@ async def test_user_status(
         },
     )
     assert r.status_code == 200
-    expected_resources = size_manager.resources[LabSize(lab.options.size)]
+    expected_resources = size_manager.resources(lab.options.size)
     assert r.json() == {
         "env": lab.env,
         "events": [],

--- a/tests/services/lab_test.py
+++ b/tests/services/lab_test.py
@@ -140,10 +140,12 @@ async def test_pod_spec(
     lab = obj_factory.labspecs[0]
     assert lab.options.image_list
     lab_manager = factory.create_lab_manager()
+    size_manager = factory.create_size_manager()
 
     reference = DockerReference.from_str(lab.options.image_list)
     image = await factory.image_service.image_for_reference(reference)
-    pod_spec = lab_manager.build_pod_spec(user, image)
+    resources = size_manager.resources(lab.options.size)
+    pod_spec = lab_manager.build_pod_spec(user, resources, image)
     with (std_result_dir / "pod.json").open("r") as f:
         expected = json.load(f)
     assert strip_none(pod_spec.to_dict()) == expected

--- a/tests/services/size_test.py
+++ b/tests/services/size_test.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from jupyterlabcontroller.config import Configuration
+from jupyterlabcontroller.models.v1.lab import LabSize
 from jupyterlabcontroller.services.size import SizeManager
 
 
@@ -13,8 +14,8 @@ async def test_resources(config: Configuration, std_result_dir: Path) -> None:
     with (std_result_dir / "sizemanager-resources.json").open("r") as f:
         expected = json.load(f)
     size_manager = SizeManager(sizes=config.lab.sizes)
-    resources = {k: v.dict() for k, v in size_manager.resources.items()}
-    assert resources == expected
+    for size, resources in expected.items():
+        assert size_manager.resources(LabSize(size)).dict() == resources
 
 
 @pytest.mark.asyncio
@@ -22,4 +23,4 @@ async def test_form(config: Configuration, std_result_dir: Path) -> None:
     with (std_result_dir / "sizemanager-formdata.json").open("r") as f:
         expected = json.load(f)
     size_manager = SizeManager(sizes=config.lab.sizes)
-    assert [asdict(d) for d in size_manager.formdata] == expected
+    assert [asdict(d) for d in size_manager.formdata()] == expected


### PR DESCRIPTION
When I added support for Gafaelfawr quota settings, it broke pod spawning because I missed some pieces. Set resource requests and quotas on the pod based on the size of pod requested by the user, and set the same requests and limits for the init container (even though it probably won't need nearly as much) since that preserves the same total pod requirements and is easy.

Refactor the size manager to use methods rather than properties that do a lot of work, and to return the resources for a specific lab size, which is a bit more convenient elsewhere in the code.