### PR TITLE
DM-38279: Change order of progress messages

### DIFF
--- a/src/jupyterlabcontroller/services/lab.py
+++ b/src/jupyterlabcontroller/services/lab.py
@@ -96,8 +96,8 @@ class LabManager:
             )
         ev_queue = self.event_manager.get(username)
         umsg = f"{message} for {username}"
-        await ev_queue.asend(Event(data=umsg, event=EventTypes.INFO))
         await ev_queue.asend(Event(data=str(pct), event=EventTypes.PROGRESS))
+        await ev_queue.asend(Event(data=umsg, event=EventTypes.INFO))
         self.logger.info(f"Event: {umsg}: {pct}% ")
 
     async def completion_event(self, username: str) -> None:


### PR DESCRIPTION
Send the new progress percentage before the message, since the REST spawner class needs the new progress percentage when it emits the message.