### PR TITLE
DM-38279: Return 201 from lab create route

### DIFF
--- a/tests/handlers/user_status_test.py
+++ b/tests/handlers/user_status_test.py
@@ -48,7 +48,10 @@ async def test_user_status(
             "X-Auth-Request-User": user.username,
         },
     )
-    assert r.status_code == 303
+    assert r.status_code == 201
+    assert r.headers["Location"] == (
+        f"http://localhost:8080/nublado/spawner/v1/labs/{user.username}"
+    )
 
     # Now the lab should exist and we should be able to get some user status.
     r = await app_client.get(


### PR DESCRIPTION
The URL to which we redirected the lab creation response is protected by different authentication rules and would require a different token. This probably indicates a deeper problem that we should rethink, but since the REST spawner doesn't want to follow the redirect anyway, return 201 with an empty body and a Location header instead.