### PR TITLE
DM-38279: Don't overwrite pod labels

### DIFF
--- a/src/jupyterlabcontroller/storage/k8s.py
+++ b/src/jupyterlabcontroller/storage/k8s.py
@@ -496,7 +496,7 @@ class K8sStorageClient:
             pod.image_pull_secrets = [{"name": "pull-secret"}]
         metadata = self.get_std_metadata(name, namespace=namespace)
         if labels:
-            metadata.labels = labels
+            metadata.labels.update(labels)
         pod_obj = V1Pod(metadata=metadata, spec=pod)
         try:
             await self.api.create_namespaced_pod(


### PR DESCRIPTION
The standard Argo CD labels for the pod weren't present because they were overwritten by the extra label we wanted to add. Update the dict instead of overwriting it.