### PR TITLE
DM-38279: Fix handling of image_dropdown

### DIFF
--- a/src/jupyterlabcontroller/constants.py
+++ b/src/jupyterlabcontroller/constants.py
@@ -16,6 +16,7 @@ ADMIN_SCOPE = "admin:jupyterlab"
 USER_SCOPE = "exec:notebook"
 
 DROPDOWN_SENTINEL_VALUE = "use_image_from_dropdown"
+"""Used in the lab form for ``image_list`` when ``image_dropdown`` is used."""
 
 # These are in seconds; they're arguments to various functions, not timedeltas.
 KUBERNETES_REQUEST_TIMEOUT = 60

--- a/src/jupyterlabcontroller/models/v1/lab.py
+++ b/src/jupyterlabcontroller/models/v1/lab.py
@@ -151,7 +151,7 @@ class UserOptions(BaseModel):
         for k in ("image_list", "image_dropdown", "image_class", "image_tag"):
             if values.get(k) is not None:
                 if k == "image_list" and values[k] == DROPDOWN_SENTINEL_VALUE:
-                    del values[k]
+                    values[k] = None
                     continue
                 values_set.add(k)
         if values_set == {"image_list", "image_dropdown"}:


### PR DESCRIPTION
The validator was deleting image_list entirely when image_dropdown was set, but we later need to check whether it is None. Set it to None in this case instead.