### PR TITLE
DM-38279: Don't return an event stream for nonexistent users

### DIFF
--- a/src/jupyterlabcontroller/handlers/labs.py
+++ b/src/jupyterlabcontroller/handlers/labs.py
@@ -136,6 +136,13 @@ async def get_user_events(
     """Returns the events for the lab of the given user"""
     if username != x_auth_request_user:
         raise HTTPException(status_code=403, detail="Forbidden")
+
+    # If the user doesn't exist, publishing events for them will just hang
+    # forever, so return an immediate 404. No one should watch for events
+    # before creating a lab.
+    if not context.user_map.get(username):
+        raise HTTPException(status_code=404, detail="Not found")
+
     return context.event_manager.publish(username)
 
 


### PR DESCRIPTION
If someone asks us for events for a user that we've never heard of, we'll just block forever unless someone happens to create a lab for that user. Instead, return 404 if we've never heard of the user. Labs should always be created before asking for their events, and if the lab doesn't exist, the events shouldn't either.