### PR TITLE
DM-38279: Use a start script to start the application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,9 @@ RUN useradd --create-home appuser
 # Copy the virtualenv
 COPY --from=install-image /opt/venv /opt/venv
 
+# Copy the startup script
+COPY scripts/start.sh /start.sh
+
 # Make sure we use the virtualenv
 ENV PATH="/opt/venv/bin:$PATH"
 
@@ -65,4 +68,4 @@ USER appuser
 EXPOSE 8080
 
 # Run the application.
-CMD ["uvicorn", "jupyterlabcontroller.main:create_app", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["/start.sh"]

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# Start the lab controller application inside the Docker image.
+
+set -eu
+
+uvicorn --factory jupyterlabcontroller.main:create_app \
+    --host 0.0.0.0 --port 8080

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Start the lab controller application inside the Docker image.
 


### PR DESCRIPTION
Follow the pattern from Gafaelfawr, even though our start command is fairly simple. Add the --factory flag, which uvicorn warns is missing when not provided.