### PR TITLE
DM-38279: Wait for first image service run during startup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,10 +94,6 @@ async def factory(
     """Create a component factory for tests."""
     mock_kubernetes.set_nodes_for_test(obj_factory.nodecontents)
     async with Factory.standalone(config) as factory:
-        # Currently, always start background processes since tests expect it.
-        # This is temporary until tests can be refactored to decide whether
-        # they want background processes running.
-        await factory.start_background_services()
         yield factory
 
 

--- a/tests/services/lab_test.py
+++ b/tests/services/lab_test.py
@@ -1,7 +1,5 @@
 """Tests for the lab service."""
 
-import asyncio
-
 import pytest
 
 from jupyterlabcontroller.factory import Factory
@@ -16,6 +14,7 @@ async def test_lab_manager(
     token, user = obj_factory.get_user()
     lab = obj_factory.labspecs[0]
     lab_manager = factory.create_lab_manager()
+    await factory.start_background_services()
 
     assert not lab_manager.check_for_user(user.username)
     await lab_manager.create_lab(user, token, lab)
@@ -33,6 +32,7 @@ async def test_get_active_users(
     token, user = obj_factory.get_user()
     lab = obj_factory.labspecs[0]
     lab_manager = factory.create_lab_manager()
+    await factory.start_background_services()
 
     assert await factory.user_map.running() == []
 
@@ -43,8 +43,4 @@ async def test_get_active_users(
     assert await factory.user_map.running() == [user.username]
 
     await lab_manager.delete_lab(user.username)
-
-    # We have to let the background task run and complete the namespace
-    # deletion.
-    await asyncio.sleep(0.2)
     assert await factory.user_map.running() == []


### PR DESCRIPTION
We don't want to start answering user requests until we've populated our list of available images, since otherwise the spawner form may be bogus. Implement this by not returning from start until the first update pass is complete.

Don't start background services by default when using a test factory and update the tests that use it to start the background services themselves.