### PR TITLE
DM-38466: Move more image operations into RSPImageCollection

### DIFF
--- a/src/jupyterlabcontroller/models/domain/rspimage.py
+++ b/src/jupyterlabcontroller/models/domain/rspimage.py
@@ -501,7 +501,7 @@ class RSPImageCollection:
                 new.aliases.add(alias)
                 other = self._by_tag_name[alias]
                 if other.alias_target == old.tag:
-                    other.alias_target = new.tag
+                    other.resolve_alias(new)
                     other.aliases.add(old.tag)
                 else:
                     other.aliases.add(new.tag)

--- a/src/jupyterlabcontroller/models/domain/rspimage.py
+++ b/src/jupyterlabcontroller/models/domain/rspimage.py
@@ -41,8 +41,17 @@ class RSPImage(RSPImageTag):
     size: Optional[int] = None
     """Size of the image in bytes if known."""
 
+    aliased: bool = False
+    """Whether this is the "real" image underlying an alias tag."""
+
     aliases: set[str] = field(default_factory=set)
-    """Known aliases for this image."""
+    """Known aliases for this image.
+
+    This may include other alias tags that all resolve to the same underlying
+    image. To determine whether this is a "real" image pointed to by an alias
+    (in other words, an image that is some other alias image's
+    ``alias_target``), use ``aliased``.
+    """
 
     alias_target: Optional[str] = None
     """The tag of the image for which this is an alias, if known."""
@@ -121,6 +130,7 @@ class RSPImage(RSPImageTag):
             raise ValueError("Can only resolve alias and unknown images")
         self.image_type = RSPImageType.ALIAS
         self.alias_target = target.tag
+        target.aliased = True
         target.aliases.add(self.tag)
         base_display_name = self.tag.replace("_", " ").title()
         self.display_name = f"{base_display_name} ({target.display_name})"
@@ -173,8 +183,16 @@ class RSPImageCollection:
             if other.image_type in _ALIAS_TYPES:
                 self._unresolved_aliases[image.digest].append(image)
             else:
+                for alias in other.aliases:
+                    if alias == image.tag:
+                        continue
+                    image.aliases.add(alias)
+                    self._by_tag_name[alias].aliases.add(image.tag)
                 image.resolve_alias(other)
         else:
+            if image.digest in self._by_digest:
+                self._by_digest[image.digest].aliases.add(image.tag)
+                image.aliases.add(self._by_digest[image.digest].tag)
             self._by_digest[image.digest] = image
         self._by_tag_name[image.tag] = image
         self._by_type[image.image_type].append(image)
@@ -204,7 +222,7 @@ class RSPImageCollection:
         """
         for image_type in RSPImageType:
             for image in self._by_type[image_type]:
-                if hide_aliased and image.aliases:
+                if hide_aliased and image.aliased:
                     continue
                 if hide_resolved_aliases and image.alias_target:
                     continue
@@ -250,6 +268,51 @@ class RSPImageCollection:
         images = self._by_type[image_type]
         return images[0] if images else None
 
+    def subset(
+        self,
+        *,
+        releases: int = 0,
+        weeklies: int = 0,
+        dailies: int = 0,
+        include: Optional[set[str]] = None,
+    ) -> RSPImageCollection:
+        """Return a subset of the image collection.
+
+        Parameters
+        ----------
+        releases
+            Number of releases to include.
+        weeklies
+            Number of weeklies to include.
+        dailies
+            Number of dailies to include.
+        include
+            Include this list of tags even if they don't meet other criteria.
+
+        Returns
+        -------
+        RSPImageCollection
+            The desired subset.
+        """
+        images = []
+
+        # Extract the desired image types.
+        if releases and RSPImageType.RELEASE in self._by_type:
+            images.extend(self._by_type[RSPImageType.RELEASE][0:releases])
+        if weeklies and RSPImageType.WEEKLY in self._by_type:
+            images.extend(self._by_type[RSPImageType.WEEKLY][0:weeklies])
+        if dailies and RSPImageType.DAILY in self._by_type:
+            images.extend(self._by_type[RSPImageType.DAILY][0:dailies])
+
+        # Include additional images if they're present in the collection.
+        if include:
+            for tag in include:
+                if tag in self._by_tag_name:
+                    images.append(self._by_tag_name[tag])
+
+        # Return the results.
+        return RSPImageCollection(images)
+
     def subtract(self, other: RSPImageCollection) -> RSPImageCollection:
         """Find the list of images in this collection missing from another.
 
@@ -292,14 +355,19 @@ class RSPImageCollection:
         self._by_type = defaultdict(list)
         self._unresolved_aliases = defaultdict(list)
 
-        # First pass: store all images other than unresolved images by digest.
-        # If there is a conflict between two non-alias images, the last one
-        # wins.  (This is for no particular reason except that it's easy.)
+        # First pass: store all images by tag name, and all images other than
+        # unresolved images by digest. If there is a conflict between two
+        # non-alias images, the last one wins. (This is for no particular
+        # reason except that it's easy.)
         unresolved = []
         for image in images:
+            self._by_tag_name[image.tag] = image
             if image.is_possible_alias:
                 unresolved.append(image)
             else:
+                if image.digest in self._by_digest:
+                    self._by_digest[image.digest].aliases.add(image.tag)
+                    image.aliases.add(self._by_digest[image.digest].tag)
                 self._by_digest[image.digest] = image
 
         # Second pass: add the unresolved images now that any images they
@@ -312,17 +380,23 @@ class RSPImageCollection:
             if image.digest in self._by_digest:
                 other = self._by_digest[image.digest]
                 if other.is_possible_alias:
+                    image.aliases.add(other.tag)
+                    other.aliases.add(image.tag)
                     self._unresolved_aliases[image.digest].append(image)
                 else:
                     image.resolve_alias(other)
+                for alias in other.aliases:
+                    if alias == image.tag or alias not in self._by_tag_name:
+                        continue
+                    image.aliases.add(alias)
+                    self._by_tag_name[alias].aliases.add(image.tag)
             else:
                 self._unresolved_aliases[image.digest].append(image)
                 self._by_digest[image.digest] = image
 
         # Now, all images have been resolved where possible. Take a second
-        # pass and register all images by name and type.
+        # pass and register all images by type.
         for image in images:
-            self._by_tag_name[image.tag] = image
             self._by_type[image.image_type].append(image)
 
         # Sort all of the images by reverse order so the newest are first.

--- a/src/jupyterlabcontroller/models/domain/rspimage.py
+++ b/src/jupyterlabcontroller/models/domain/rspimage.py
@@ -264,6 +264,37 @@ class RSPImageCollection:
         images = self._by_type[image_type]
         return images[0] if images else None
 
+    def mark_image_seen_on_node(
+        self, digest: str, node: str, image_size: Optional[int] = None
+    ) -> None:
+        """Mark an image as seen on a node.
+
+        This is implemented by the image collection so that we can update all
+        of the image's aliases as well.
+
+        Parameters
+        ----------
+        digest
+            Digest of image seen.
+        node
+            Name of the node the image was seen on.
+        image_size
+            If given, the observed image size, used to update the images.
+        """
+        if digest not in self._by_digest:
+            return
+        image = self._by_digest[digest]
+        image.nodes.add(node)
+        if image_size:
+            image.size = image_size
+        for alias in image.aliases:
+            if alias not in self._by_tag_name:
+                continue
+            other = self._by_tag_name[alias]
+            other.nodes.add(node)
+            if image_size:
+                other.size = image_size
+
     def subset(
         self,
         *,

--- a/src/jupyterlabcontroller/models/domain/rspimage.py
+++ b/src/jupyterlabcontroller/models/domain/rspimage.py
@@ -45,9 +45,10 @@ class RSPImage(RSPImageTag):
     """Known aliases for this image.
 
     This may include other alias tags that all resolve to the same underlying
-    image. To determine whether this is a "real" image pointed to by an alias
-    (in other words, an image that is some other alias image's
-    ``alias_target``), use ``aliased``.
+    image, other non-alias tags with the same digest, and aliases that are not
+    present in the same collection. It is intended primarily for the use of
+    `RSPImageCollection`, which contains more sophisticated alias tracking
+    logic that is aware of the contents of the collection.
     """
 
     alias_target: Optional[str] = None

--- a/tests/models/domain/rspimage_test.py
+++ b/tests/models/domain/rspimage_test.py
@@ -273,7 +273,7 @@ def test_alias_tracking() -> None:
     # all alias each other, with the alias tags pointing to the non-alias tags
     # using the alias_target attribute and the non-alias tags marked as
     # aliased.
-    images = [old_weekly, weekly, recommended, latest_weekly]
+    images = [weekly, old_weekly, recommended, latest_weekly]
     collection = RSPImageCollection(images)
     assert weekly.aliases == {"recommended", "latest_weekly", "w_2077_45"}
     assert weekly.aliased

--- a/tests/models/domain/rspimage_test.py
+++ b/tests/models/domain/rspimage_test.py
@@ -359,6 +359,7 @@ def test_alias_tracking() -> None:
 
     # If we add another image with the same digest, it should take over as the
     # primary alias target.
+    assert recommended.display_name == "Recommended (Weekly 2077_46)"
     new_weekly = make_test_image("w_2077_47")
     new_weekly.digest = weekly.digest
     collection.add(new_weekly)
@@ -368,6 +369,7 @@ def test_alias_tracking() -> None:
     assert not new_weekly.alias_target
     assert recommended.aliases == {"latest_weekly", "w_2077_46"}
     assert recommended.alias_target == "w_2077_47"
+    assert recommended.display_name == "Recommended (Weekly 2077_47)"
     assert latest_weekly.aliases == {"recommended", "w_2077_46"}
     assert latest_weekly.alias_target == "w_2077_47"
     assert [i.tag for i in collection.all_images(hide_aliased=True)] == [

--- a/tests/models/domain/rspimage_test.py
+++ b/tests/models/domain/rspimage_test.py
@@ -34,6 +34,7 @@ def test_image() -> None:
         "repository": "library/sketchbook",
         "digest": "sha256:1234",
         "size": None,
+        "aliased": False,
         "aliases": set(),
         "alias_target": None,
         "nodes": set(),
@@ -166,6 +167,27 @@ def test_collection() -> None:
         "w_2077_43",
         "d_2077_10_21",
     ]
+
+    # Test subsetting.
+    subset = collection.subset(releases=1, weeklies=3, dailies=1)
+    assert [t.tag for t in subset.all_images()] == [
+        "w_2077_46",
+        "w_2077_45",
+        "w_2077_44",
+        "d_2077_10_21",
+    ]
+    subset = collection.subset(
+        releases=1, weeklies=3, dailies=1, include={"recommended"}
+    )
+    assert [t.tag for t in subset.all_images()] == [
+        "recommended",
+        "w_2077_46",
+        "w_2077_45",
+        "w_2077_44",
+        "d_2077_10_21",
+    ]
+    subset = subset.subset(weeklies=1)
+    assert [t.tag for t in subset.all_images()] == ["w_2077_46"]
 
     # Test subtraction. Note that this only returns one image per digest and
     # prefers the non-alias images.


### PR DESCRIPTION
With Google Artifact Registry, we can use an `RSPImageCollection` to hold all known images, rather than using the more limited `RSPImageTagCollection` because (with Docker) we don't have digests. `RSPImageCollection` therefore needs a `subset` operation to generate the list of prepulled images.

Alias tracking of images was incomplete: it didn't handle the case of multiple aliases pointing to the same image or non-alias tags with the same digest. The flags to `all_images` also hid images based on whether we had ever seen an alias even if that alias wasn't in the same collection, which wasn't desirable. Fix both of those problems by adding more sophisticated alias tracking to `RSPImageCollection`.

Similarly, the code for updating which nodes an image was present on was not sophisticated enough to understand alias relationships. Move that into `RSPImageCollection` so that it can share the same alias chasing logic.

This PR only updates the abstract data type but doesn't yet use the new functionality. That will be coming in the next PR that adds Google Artifact Registry support and refactors the image service.