### PR TITLE
DM-38554: Move ACCESS_TOKEN out of the ConfigMap

### DIFF
--- a/tests/configs/standard/output/lab-objects.json
+++ b/tests/configs/standard/output/lab-objects.json
@@ -40,7 +40,6 @@
       "MEM_GUARANTEE": "805306368",
       "MEM_LIMIT": "3221225472",
       "EXTERNAL_INSTANCE_URL": "http://127.0.0.1:8080",
-      "ACCESS_TOKEN": "token-of-affection",
       "HOME": "/home/ceres",
       "SHELL": "/bin/bash"
     },
@@ -149,6 +148,16 @@
             "/opt/lsst/software/jupyterlab/runlab.sh"
           ],
           "env": [
+            {
+              "name": "ACCESS_TOKEN",
+              "value_from": {
+                "secret_key_ref": {
+                  "key": "token",
+                  "name": "nb-rachel",
+                  "optional": false
+                }
+              }
+            },
             {
               "name": "K8S_NODE_NAME",
               "value_from": {


### PR DESCRIPTION
Inject ACCESS_TOKEN into the environment directly from the secret rather than putting a copy of it into the environment ConfigMap.