### PR TITLE
DM-38554: Change lab pull policy to IfNotPresent

### DIFF
--- a/src/jupyterlabcontroller/services/lab.py
+++ b/src/jupyterlabcontroller/services/lab.py
@@ -795,13 +795,8 @@ class LabManager:
                 ),
             ],
             image=image.reference_with_digest,
-            image_pull_policy="Always",
-            ports=[
-                V1ContainerPort(
-                    container_port=8888,
-                    name="jupyterlab",
-                ),
-            ],
+            image_pull_policy="IfNotPresent",
+            ports=[V1ContainerPort(container_port=8888, name="jupyterlab")],
             resources=V1ResourceRequirements(
                 limits={
                     "cpu": str(resources.limits.cpu),

--- a/tests/configs/standard/output/lab-objects.json
+++ b/tests/configs/standard/output/lab-objects.json
@@ -175,7 +175,7 @@
             }
           ],
           "image": "lighthouse.ceres/library/sketchbook:d_2077_10_23@sha256:1234",
-          "image_pull_policy": "Always",
+          "image_pull_policy": "IfNotPresent",
           "name": "notebook",
           "ports": [
             {


### PR DESCRIPTION
Now that we always spawn labs by digest, a pull policy of Always isn't doing anything for us other than adding unnecessary polling of the underlying image registry. Switch to IfNotPresent.