### PR TITLE
DM-38554: Rework how pull secrets are implemented

### DIFF
--- a/src/jupyterlabcontroller/config.py
+++ b/src/jupyterlabcontroller/config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 from enum import Enum
 from pathlib import Path
-from typing import Self
+from typing import Optional, Self
 
 import yaml
 from pydantic import BaseSettings, Field
@@ -194,12 +194,29 @@ class LabFile(CamelCaseModel):
 
 
 class LabConfig(CamelCaseModel):
-    sizes: dict[LabSize, LabSizeDefinition] = {}
-    env: dict[str, str] = {}
-    secrets: list[LabSecret] = []
-    files: dict[str, LabFile] = {}
-    volumes: list[LabVolume] = []
-    init_containers: list[LabInitContainer] = []
+    sizes: dict[LabSize, LabSizeDefinition] = Field(
+        {}, title="Lab sizes users may choose from"
+    )
+    env: dict[str, str] = Field(
+        {}, title="Environment variables to set in user lab"
+    )
+    secrets: list[LabSecret] = Field(
+        [], title="Secrets to make available inside lab"
+    )
+    files: dict[str, LabFile] = Field({}, title="Files to mount inside lab")
+    volumes: list[LabVolume] = Field([], title="Volumes to mount inside lab")
+    init_containers: list[LabInitContainer] = Field(
+        [], title="Initialization containers to run before user's lab starts"
+    )
+    pull_secret: Optional[str] = Field(
+        None,
+        title="Pull secret to use for lab pods",
+        description=(
+            "If set, must be the name of a secret in the same namespace as"
+            " the lab controller. This secret is copied to the user's lab"
+            " namespace and referenced as a pull secret in the pod object."
+        ),
+    )
     namespace_prefix: str = Field(
         default_factory=_get_namespace_prefix,
         title="Namespace prefix for lab environments",

--- a/tests/configs/standard/input/config.yaml
+++ b/tests/configs/standard/input/config.yaml
@@ -64,9 +64,7 @@ lab:
     #
     # EXTERNAL_INSTANCE_URL is a special case: it's constant-per-instance, but
     # you can't template values files
-  secrets:
-    - secretName: pull_secret
-      secretKey: ".dockerconfigjson"
+  pullSecret: pull-secret
   files:
     /etc/passwd:
       modify: true

--- a/tests/configs/standard/output/lab-objects.json
+++ b/tests/configs/standard/output/lab-objects.json
@@ -262,6 +262,11 @@
           "working_dir": "/home/rachel"
         }
       ],
+      "image_pull_secrets": [
+        {
+          "name": "pull-secret"
+        }
+      ],
       "init_containers": [],
       "restart_policy": "OnFailure",
       "security_context": {

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -141,6 +141,8 @@ class TestObjectFactory:
             secret = V1Secret(
                 metadata=V1ObjectMeta(name=name), data=encoded_data
             )
+            if ".dockerconfigjson" in data:
+                secret.type = "kubernetes.io/dockerconfigjson"
             secrets.append(secret)
         return secrets
 


### PR DESCRIPTION
Rather than listing the pull secret like any other secret and then separating it out if it's named pull-secret, use a separate configuration option specifying the pull secret to copy and explicitly copy it in the lab service independent of creation of other lab secrets.