### PR TITLE
DM-38554: Add support for exposing secrets in more ways

### DIFF
--- a/tests/configs/standard/input/config.yaml
+++ b/tests/configs/standard/input/config.yaml
@@ -64,7 +64,6 @@ lab:
     #
     # EXTERNAL_INSTANCE_URL is a special case: it's constant-per-instance, but
     # you can't template values files
-  pullSecret: pull-secret
   files:
     /etc/passwd:
       modify: true
@@ -148,6 +147,14 @@ lab:
         #url_prefix = /idds
         #cacher_dir = /tmp
         cacher_dir = /data/idds
+  pullSecret: pull-secret
+  secrets:
+    - secretName: nublado-secret
+      secretKey: butler-secret
+      env: BUTLER_SECRET
+      path: /opt/lsst/software/jupyterlab/butler-secret
+    - secretName: extra-secret
+      secretKey: db-password
 images:
   source:
     type: docker

--- a/tests/configs/standard/input/test_objects.json
+++ b/tests/configs/standard/input/test_objects.json
@@ -123,6 +123,13 @@
     "d_2077_10_23": "sha256:1234"
   },
   "secrets": {
+    "extra-secret": {
+      "db-password": "some database password"
+    },
+    "nublado-secret": {
+      "butler-secret": "some butler secret",
+      "other-key": "some other key that isn't used"
+    },
     "pull-secret": {
       ".dockerconfigjson": "someencodedauthstring"
     }

--- a/tests/configs/standard/output/lab-objects.json
+++ b/tests/configs/standard/output/lab-objects.json
@@ -165,6 +165,16 @@
                   "field_path": "spec.nodeName"
                 }
               }
+            },
+            {
+              "name": "BUTLER_SECRET",
+              "value_from": {
+                "secret_key_ref": {
+                  "key": "butler-secret",
+                  "name": "nb-rachel",
+                  "optional": false
+                }
+              }
             }
           ],
           "env_from": [
@@ -257,6 +267,12 @@
               "mount_path": "/opt/lsst/software/jupyterlab/runtime",
               "name": "nb-rachel-runtime",
               "read_only": true
+            },
+            {
+              "mount_path": "/opt/lsst/software/jupyterlab/butler-secret",
+              "name": "nb-rachel-secrets",
+              "read_only": true,
+              "sub_path": "butler-secret"
             }
           ],
           "working_dir": "/home/rachel"
@@ -416,6 +432,8 @@
   {
     "api_version": "v1",
     "data": {
+      "butler-secret": "c29tZSBidXRsZXIgc2VjcmV0",
+      "db-password": "c29tZSBkYXRhYmFzZSBwYXNzd29yZA==",
       "token": "dG9rZW4tb2YtYWZmZWN0aW9u"
     },
     "immutable": true,


### PR DESCRIPTION
To make it easier to transition from the old Nublado, add support for mounting secrets and injecting them as environment variables. Add a test for supplemental secrets in addition to the pull secret.