### PR TITLE
DM-38554: Rename K8S_NODE_NAME to KUBERNETES_NODE_NAME

### DIFF
--- a/src/jupyterlabcontroller/services/lab.py
+++ b/src/jupyterlabcontroller/services/lab.py
@@ -780,7 +780,7 @@ class LabManager:
             # spec.nodeName is not reflected in DownwardAPIVolumeSource:
             # https://github.com/kubernetes/kubernetes/issues/64168
             V1EnvVar(
-                name="K8S_NODE_NAME",
+                name="KUBERNETES_NODE_NAME",
                 value_from=V1EnvVarSource(
                     field_ref=V1ObjectFieldSelector(field_path="spec.nodeName")
                 ),

--- a/tests/configs/standard/output/lab-objects.json
+++ b/tests/configs/standard/output/lab-objects.json
@@ -159,7 +159,7 @@
               }
             },
             {
-              "name": "K8S_NODE_NAME",
+              "name": "KUBERNETES_NODE_NAME",
               "value_from": {
                 "field_ref": {
                   "field_path": "spec.nodeName"


### PR DESCRIPTION
Avoid cryptic abbreviations in environment variables that are exposed to users.