### PR TITLE
DM-38554: Use structured exceptions for expected errors

### DIFF
--- a/src/jupyterlabcontroller/exceptions.py
+++ b/src/jupyterlabcontroller/exceptions.py
@@ -121,6 +121,13 @@ class PermissionDeniedError(ValidationError):
     status_code = status.HTTP_403_FORBIDDEN
 
 
+class UnknownUserError(ValidationError):
+    """No resource has been created for this user."""
+
+    error = "unknown_user"
+    status_code = status.HTTP_404_NOT_FOUND
+
+
 class UnknownDockerImageError(Exception):
     """Cannot find a Docker image matching the requested parameters."""
 
@@ -163,7 +170,3 @@ class InvalidUserError(Exception):
 
 class MissingSecretError(Exception):
     """Secret specified in the controller configuration was not found."""
-
-
-class UnknownUserError(Exception):
-    """No resource has been created for this user."""

--- a/src/jupyterlabcontroller/exceptions.py
+++ b/src/jupyterlabcontroller/exceptions.py
@@ -134,15 +134,18 @@ class LabExistsError(ValidationError):
     status_code = status.HTTP_409_CONFLICT
 
 
+class UnknownDockerImageError(ValidationError):
+    """Cannot find a Docker image matching the requested parameters."""
+
+    error = "unknown_image"
+    status_code = status.HTTP_400_BAD_REQUEST
+
+
 class UnknownUserError(ValidationError):
     """No resource has been created for this user."""
 
     error = "unknown_user"
     status_code = status.HTTP_404_NOT_FOUND
-
-
-class UnknownDockerImageError(Exception):
-    """Cannot find a Docker image matching the requested parameters."""
 
 
 class DockerRegistryError(Exception):

--- a/src/jupyterlabcontroller/exceptions.py
+++ b/src/jupyterlabcontroller/exceptions.py
@@ -1,80 +1,74 @@
-class InvalidDockerReferenceError(Exception):
-    """Docker reference is not valid."""
+"""Exceptions for the Nublado lab controller."""
 
-    pass
+from __future__ import annotations
+
+__all__ = [
+    "DockerRegistryError",
+    "GafaelfawrError",
+    "InvalidDockerReferenceError",
+    "InvalidUserError",
+    "KubernetesError",
+    "LabExistsError",
+    "MissingSecretError",
+    "NoUserMapError",
+    "NSCreationError",
+    "NSDeletionError",
+    "UnknownDockerImageError",
+    "UnknownUserError",
+    "WaitingForObjectError",
+]
+
+
+class InvalidDockerReferenceError(Exception):
+    """Docker reference does not contain a tag.
+
+    This is valid to Docker, but for references without a digest we require a
+    tag for debugging, status display inside the lab, etc.
+    """
 
 
 class UnknownDockerImageError(Exception):
     """Cannot find a Docker image matching the requested parameters."""
 
-    pass
-
 
 class DockerRegistryError(Exception):
-    """Unknown error working with the Docker registry."""
-
-    pass
+    """An API call to a Docker Registry failed."""
 
 
 class NSCreationError(Exception):
     """Error while attempting namespace creation."""
 
-    pass
-
 
 class NSDeletionError(Exception):
     """Error while attempting namespace deletion."""
 
-    pass
-
 
 class WaitingForObjectError(Exception):
-    """Error raised when something goes wrong waiting for object creation/
-    deletion."""
-
-    pass
+    """An error occurred while waiting for object creation or deletion."""
 
 
 class KubernetesError(Exception):
-    """Generic error for something keeling over in the K8s layer."""
-
-    pass
+    """An API call to Kubernetes failed."""
 
 
 class LabExistsError(Exception):
-    """Raised when lab creation is attempted for a user with an active lab."""
-
-    pass
+    """Lab creation was attempted for a user with an active lab."""
 
 
 class NoUserMapError(Exception):
-    """Raised when a user deletion is called for a user without a lab."""
-
-    pass
+    """Lab deletion was attempted for a user without a lab."""
 
 
 class GafaelfawrError(Exception):
-    """An unexpected error occurred talking to Gafaelfawr."""
-
-    pass
+    """An API call to Gafaelfawr failed."""
 
 
 class InvalidUserError(Exception):
-    """Raised when a user cannot be resolved from a token."""
-
-    pass
+    """The delegated user token is invalid."""
 
 
 class MissingSecretError(Exception):
-    """Raised when we try to copy a non-existent secret."""
-
-    pass
-
-
-class StateUpdateError(Exception):
-    """Raised when an attempt to update prepuller state fails."""
-
-    pass
+    """Secret specified in the controller configuration was not found."""
 
 
 class UnknownUserError(Exception):

--- a/src/jupyterlabcontroller/exceptions.py
+++ b/src/jupyterlabcontroller/exceptions.py
@@ -12,7 +12,7 @@ __all__ = [
     "DockerRegistryError",
     "GafaelfawrError",
     "InvalidDockerReferenceError",
-    "InvalidUserError",
+    "InvalidTokenError",
     "KubernetesError",
     "LabExistsError",
     "MissingSecretError",
@@ -113,6 +113,13 @@ class InvalidDockerReferenceError(ValidationError):
     error = "invalid_docker_reference"
 
 
+class InvalidTokenError(ValidationError):
+    """The delegated user token is invalid."""
+
+    error = "invalid_token"
+    status_code = status.HTTP_401_UNAUTHORIZED
+
+
 class PermissionDeniedError(ValidationError):
     """Attempt to access a resource for another user."""
 
@@ -160,10 +167,6 @@ class KubernetesError(Exception):
 
 class GafaelfawrError(Exception):
     """An API call to Gafaelfawr failed."""
-
-
-class InvalidUserError(Exception):
-    """The delegated user token is invalid."""
 
 
 class MissingSecretError(Exception):

--- a/src/jupyterlabcontroller/exceptions.py
+++ b/src/jupyterlabcontroller/exceptions.py
@@ -114,6 +114,13 @@ class InvalidDockerReferenceError(ValidationError):
     error = "invalid_docker_reference"
 
 
+class PermissionDeniedError(ValidationError):
+    """Attempt to access a resource for another user."""
+
+    error = "permission_denied"
+    status_code = status.HTTP_403_FORBIDDEN
+
+
 class UnknownDockerImageError(Exception):
     """Cannot find a Docker image matching the requested parameters."""
 

--- a/src/jupyterlabcontroller/exceptions.py
+++ b/src/jupyterlabcontroller/exceptions.py
@@ -120,6 +120,13 @@ class PermissionDeniedError(ValidationError):
     status_code = status.HTTP_403_FORBIDDEN
 
 
+class LabExistsError(ValidationError):
+    """Lab creation was attempted for a user with an active lab."""
+
+    error = "lab_exists"
+    status_code = status.HTTP_409_CONFLICT
+
+
 class UnknownUserError(ValidationError):
     """No resource has been created for this user."""
 
@@ -149,10 +156,6 @@ class WaitingForObjectError(Exception):
 
 class KubernetesError(Exception):
     """An API call to Kubernetes failed."""
-
-
-class LabExistsError(Exception):
-    """Lab creation was attempted for a user with an active lab."""
 
 
 class GafaelfawrError(Exception):

--- a/src/jupyterlabcontroller/exceptions.py
+++ b/src/jupyterlabcontroller/exceptions.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+from typing import ClassVar, Optional
+
+from fastapi import status
+from safir.models import ErrorLocation
+from safir.slack.webhook import SlackIgnoredException
+
 __all__ = [
     "DockerRegistryError",
     "GafaelfawrError",
@@ -15,16 +21,97 @@ __all__ = [
     "NSDeletionError",
     "UnknownDockerImageError",
     "UnknownUserError",
+    "ValidationError",
     "WaitingForObjectError",
 ]
 
 
-class InvalidDockerReferenceError(Exception):
+class ValidationError(SlackIgnoredException):
+    """Represents an input validation error.
+
+    There is a global handler for this exception and all exceptions derived
+    from it that returns an HTTP 422 status code with a body that's consistent
+    with the error messages generated internally by FastAPI.  It should be
+    used for input and parameter validation errors that cannot be caught by
+    FastAPI for whatever reason.
+
+    Attributes
+    ----------
+    location
+        Part of the request giving rise to the error. This can be set by
+        catching the exception in the part of the code that knows where the
+        data came from, setting this attribute, and re-raising the exception.
+    field_path
+        Field, as a hierarchical list of structure elements, within that part
+        of the request giving rise to the error.  As with ``location``, can be
+        set by catching and re-raising.
+
+    Parameters
+    ----------
+    message
+        Error message (used as the ``msg`` key).
+    location
+        Part of the request giving rise to the error.
+    field_path
+        Field, as a hierarchical list of structure elements, in that part of
+        the request giving rise to the error.
+
+    Notes
+    -----
+    The FastAPI body format supports returning multiple errors at a time as a
+    list in the ``details`` key.  This functionality has not yet been
+    implemented.
+    """
+
+    error: ClassVar[str] = "validation_failed"
+    """Used as the ``type`` field of the error message.
+
+    Should be overridden by any subclass.
+    """
+
+    status_code: ClassVar[int] = status.HTTP_422_UNPROCESSABLE_ENTITY
+    """HTTP status code for this type of validation error."""
+
+    def __init__(
+        self,
+        message: str,
+        location: Optional[ErrorLocation] = None,
+        field_path: Optional[list[str]] = None,
+    ) -> None:
+        super().__init__(message)
+        self.location = location
+        self.field_path = field_path
+
+    def to_dict(self) -> dict[str, list[str] | str]:
+        """Convert the exception to a dictionary suitable for the exception.
+
+        Returns
+        -------
+        dict
+            Serialized error emssage to pass as the ``detail`` parameter to a
+            ``fastapi.HTTPException``.  It is designed to produce the same
+            JSON structure as native FastAPI errors.
+        """
+        result: dict[str, list[str] | str] = {
+            "msg": str(self),
+            "type": self.error,
+        }
+        if self.location:
+            if self.field_path:
+                result["loc"] = [self.location.value] + self.field_path
+            else:
+                result["loc"] = [self.location.value]
+        return result
+
+
+class InvalidDockerReferenceError(ValidationError):
     """Docker reference does not contain a tag.
 
     This is valid to Docker, but for references without a digest we require a
     tag for debugging, status display inside the lab, etc.
     """
+
+    error = "invalid_docker_reference"
 
 
 class UnknownDockerImageError(Exception):

--- a/src/jupyterlabcontroller/exceptions.py
+++ b/src/jupyterlabcontroller/exceptions.py
@@ -16,7 +16,6 @@ __all__ = [
     "KubernetesError",
     "LabExistsError",
     "MissingSecretError",
-    "NoUserMapError",
     "NSCreationError",
     "NSDeletionError",
     "UnknownDockerImageError",
@@ -154,10 +153,6 @@ class KubernetesError(Exception):
 
 class LabExistsError(Exception):
     """Lab creation was attempted for a user with an active lab."""
-
-
-class NoUserMapError(Exception):
-    """Lab deletion was attempted for a user without a lab."""
 
 
 class GafaelfawrError(Exception):

--- a/src/jupyterlabcontroller/handlers/form.py
+++ b/src/jupyterlabcontroller/handlers/form.py
@@ -1,10 +1,11 @@
 """Routes for generating spawner forms."""
 
-from fastapi import APIRouter, Depends, Header, HTTPException
+from fastapi import APIRouter, Depends, Header
 from fastapi.responses import HTMLResponse
 from safir.models import ErrorModel
 
 from ..dependencies.context import RequestContext, context_dependency
+from ..exceptions import PermissionDeniedError
 
 router = APIRouter()
 """Router to mount into the application."""
@@ -24,6 +25,6 @@ async def get_user_lab_form(
     context: RequestContext = Depends(context_dependency),
 ) -> str:
     if username != x_auth_request_user:
-        raise HTTPException(status_code=403, detail="Forbidden")
+        raise PermissionDeniedError("Permission denied")
     form_manager = context.factory.create_form_manager()
     return form_manager.generate_user_lab_form()

--- a/src/jupyterlabcontroller/handlers/labs.py
+++ b/src/jupyterlabcontroller/handlers/labs.py
@@ -48,7 +48,8 @@ async def get_userdata(
 ) -> UserData:
     userdata = context.user_map.get(username)
     if userdata is None:
-        raise HTTPException(status_code=404, detail="Not found")
+        msg = f"Unknown user {username}"
+        raise UnknownUserError(msg, ErrorLocation.path, ["username"])
     return userdata
 
 
@@ -136,5 +137,7 @@ async def get_user_events(
     try:
         generator = context.event_manager.events_for_user(username)
         return EventSourceResponse(generator)
-    except UnknownUserError:
-        raise HTTPException(status_code=404, detail="Not found")
+    except UnknownUserError as e:
+        e.location = ErrorLocation.path
+        e.field_path = ["username"]
+        raise

--- a/src/jupyterlabcontroller/handlers/labs.py
+++ b/src/jupyterlabcontroller/handlers/labs.py
@@ -8,7 +8,6 @@ from ..dependencies.context import RequestContext, context_dependency
 from ..exceptions import (
     InvalidDockerReferenceError,
     InvalidUserError,
-    LabExistsError,
     PermissionDeniedError,
     UnknownUserError,
 )
@@ -85,8 +84,6 @@ async def post_new_lab(
         field = "image_list" if lab.options.image_list else "image_dropdown"
         e.field_path = ["options", field]
         raise
-    except LabExistsError:
-        raise HTTPException(status_code=409, detail="Conflict")
     url = context.request.url_for("get_userdata", username=username)
     response.headers["Location"] = str(url)
 

--- a/src/jupyterlabcontroller/handlers/labs.py
+++ b/src/jupyterlabcontroller/handlers/labs.py
@@ -10,6 +10,7 @@ from ..exceptions import (
     InvalidUserError,
     LabExistsError,
     NoUserMapError,
+    PermissionDeniedError,
     UnknownUserError,
 )
 from ..models.v1.lab import LabSpecification, UserData
@@ -73,7 +74,7 @@ async def post_new_lab(
     except InvalidUserError:
         raise HTTPException(status_code=403, detail="Forbidden")
     if user.username != username:
-        raise HTTPException(status_code=403, detail="Forbidden")
+        raise PermissionDeniedError("Permission denied")
 
     context.logger.debug(f"Received creation request for {username}")
     lab_manager = context.factory.create_lab_manager()
@@ -131,7 +132,7 @@ async def get_user_events(
 ) -> EventSourceResponse:
     """Returns the events for the lab of the given user"""
     if username != x_auth_request_user:
-        raise HTTPException(status_code=403, detail="Forbidden")
+        raise PermissionDeniedError("Permission denied")
     try:
         generator = context.event_manager.events_for_user(username)
         return EventSourceResponse(generator)

--- a/src/jupyterlabcontroller/handlers/labs.py
+++ b/src/jupyterlabcontroller/handlers/labs.py
@@ -9,7 +9,6 @@ from ..exceptions import (
     InvalidDockerReferenceError,
     InvalidUserError,
     LabExistsError,
-    NoUserMapError,
     PermissionDeniedError,
     UnknownUserError,
 )
@@ -108,9 +107,10 @@ async def delete_user_lab(
     lab_manager = context.factory.create_lab_manager()
     try:
         await lab_manager.delete_lab(username)
-    except NoUserMapError:
-        raise HTTPException(status_code=404, detail="Not found")
-    return
+    except UnknownUserError as e:
+        e.location = ErrorLocation.path
+        e.field_path = ["username"]
+        raise
 
 
 @router.get(

--- a/src/jupyterlabcontroller/handlers/labs.py
+++ b/src/jupyterlabcontroller/handlers/labs.py
@@ -8,6 +8,7 @@ from ..dependencies.context import RequestContext, context_dependency
 from ..exceptions import (
     InvalidDockerReferenceError,
     PermissionDeniedError,
+    UnknownDockerImageError,
     UnknownUserError,
 )
 from ..models.v1.lab import LabSpecification, UserData
@@ -76,10 +77,9 @@ async def post_new_lab(
     lab_manager = context.factory.create_lab_manager()
     try:
         await lab_manager.create_lab(user, x_auth_request_token, lab)
-    except InvalidDockerReferenceError as e:
+    except (InvalidDockerReferenceError, UnknownDockerImageError) as e:
         e.location = ErrorLocation.body
-        field = "image_list" if lab.options.image_list else "image_dropdown"
-        e.field_path = ["options", field]
+        e.field_path = ["options", lab.options.image_attribute]
         raise
     url = context.request.url_for("get_userdata", username=username)
     response.headers["Location"] = str(url)

--- a/src/jupyterlabcontroller/handlers/user_status.py
+++ b/src/jupyterlabcontroller/handlers/user_status.py
@@ -1,9 +1,10 @@
 """User-facing routes that otherwise require a JupyterHub token."""
 
-from fastapi import APIRouter, Depends, Header, HTTPException
+from fastapi import APIRouter, Depends, Header
 from safir.models import ErrorModel
 
 from ..dependencies.context import RequestContext, context_dependency
+from ..exceptions import UnknownUserError
 from ..models.v1.lab import UserData
 
 router = APIRouter()
@@ -24,5 +25,5 @@ async def get_user_status(
 ) -> UserData:
     userdata = context.user_map.get(x_auth_request_user)
     if userdata is None:
-        raise HTTPException(status_code=404, detail="Not found")
+        raise UnknownUserError(f"Unknown user {x_auth_request_user}")
     return userdata

--- a/src/jupyterlabcontroller/models/v1/lab.py
+++ b/src/jupyterlabcontroller/models/v1/lab.py
@@ -123,6 +123,22 @@ class UserOptions(BaseModel):
         title="Relocate user environment (`.cache`, `.jupyter`, `.local`)",
     )
 
+    @property
+    def image_attribute(self) -> str:
+        """The name of the image attribute that was set.
+
+        Used for error reporting to know what input attribute to report when
+        the image specification was invalid.
+        """
+        if self.image_list:
+            return "image_list"
+        elif self.image_dropdown:
+            return "image_dropdown"
+        elif self.image_class:
+            return "image_class"
+        else:
+            return "image_tag"
+
     @root_validator(pre=True)
     def _validate_lists(cls, values: dict[str, Any]) -> dict[str, list[Any]]:
         """Convert from lists of length 1 to values.

--- a/src/jupyterlabcontroller/services/lab.py
+++ b/src/jupyterlabcontroller/services/lab.py
@@ -210,8 +210,8 @@ class LabManager:
         # because we don't want to wipe out the existing log, since we will
         # not be spawning.
         if self.check_for_user(username):
-            await self.failure_event(username, "lab already exists")
-            raise LabExistsError(f"lab already exists for {username}")
+            await self.failure_event(username, "Lab already exists")
+            raise LabExistsError(f"Lab already exists for {username}")
         # Add a new usermap entry
         self.user_map.set(
             username,

--- a/src/jupyterlabcontroller/services/lab.py
+++ b/src/jupyterlabcontroller/services/lab.py
@@ -37,7 +37,7 @@ from kubernetes_asyncio.client import (
 from structlog.stdlib import BoundLogger
 
 from ..config import FileMode, LabConfig, LabVolume
-from ..exceptions import LabExistsError, NoUserMapError
+from ..exceptions import LabExistsError, UnknownUserError
 from ..models.domain.docker import DockerReference
 from ..models.domain.lab import LabVolumeContainer
 from ..models.domain.rspimage import RSPImage
@@ -903,7 +903,7 @@ class LabManager:
     async def delete_lab(self, username: str) -> None:
         user = self.user_map.get(username)
         if user is None:
-            raise NoUserMapError(f"Cannot find map for user {username}")
+            raise UnknownUserError(f"Unknown user {username}")
         self.user_map.set_status(username, LabStatus.TERMINATING)
         self.user_map.clear_internal_url(username)
         #

--- a/src/jupyterlabcontroller/services/lab.py
+++ b/src/jupyterlabcontroller/services/lab.py
@@ -190,7 +190,7 @@ class LabManager:
 
         Raises
         ------
-        jupyterlabcontroller.exceptions.InvalidDockerReferenceError
+        InvalidDockerReferenceError
             Docker image reference in the lab specification is invalid.
         """
         username = user.username

--- a/src/jupyterlabcontroller/services/source/docker.py
+++ b/src/jupyterlabcontroller/services/source/docker.py
@@ -161,7 +161,7 @@ class DockerImageSource(ImageSource):
             return image
         tag = self._tags.tag_for_tag_name(tag_name)
         if not tag:
-            raise UnknownDockerImageError(f"Docker tag {tag_name} not found")
+            raise UnknownDockerImageError(f'Docker tag "{tag_name}" not found')
         digest = await self._docker.get_image_digest(self._config, tag_name)
         return RSPImage.from_tag(
             registry=self._config.registry,

--- a/src/jupyterlabcontroller/services/source/gar.py
+++ b/src/jupyterlabcontroller/services/source/gar.py
@@ -113,7 +113,7 @@ class GARImageSource(ImageSource):
         """
         image = self._images.image_for_tag_name(tag_name)
         if not image:
-            raise UnknownDockerImageError(f"Docker tag {tag_name} not found")
+            raise UnknownDockerImageError(f'Docker tag "{tag_name}" not found')
         return image
 
     def mark_prepulled(self, image: RSPImage, node: str) -> None:

--- a/src/jupyterlabcontroller/storage/gafaelfawr.py
+++ b/src/jupyterlabcontroller/storage/gafaelfawr.py
@@ -4,7 +4,7 @@ from httpx import AsyncClient
 from structlog.stdlib import BoundLogger
 
 from ..config import Config
-from ..exceptions import GafaelfawrError, InvalidUserError
+from ..exceptions import GafaelfawrError, InvalidTokenError
 from ..models.v1.lab import UserInfo
 
 
@@ -46,9 +46,9 @@ class GafaelfawrStorageClient:
 
         Raises
         ------
-        jupyterlabcontroller.exceptions.InvalidUserError
-            Token was invalid.
-        jupyterlabcontroller.exceptions.GafaelfawrError
+        InvalidTokenError
+            Raised if the token was rejected by Gafaelfawr.
+        GafaelfawrError
             Some other error occurred while talking to Gafaelfawr.
         """
         headers = {"Authorization": f"bearer {token}"}
@@ -59,7 +59,7 @@ class GafaelfawrStorageClient:
             raise GafaelfawrError(msg) from e
         if r.status_code in (401, 403):
             self._logger.warning("User token is invalid")
-            raise InvalidUserError("User token is invalid")
+            raise InvalidTokenError("User token is invalid")
         try:
             r.raise_for_status()
             return UserInfo.parse_obj(r.json())

--- a/tests/handlers/form_test.py
+++ b/tests/handlers/form_test.py
@@ -25,3 +25,15 @@ async def test_lab_form(
 
     expected = (std_result_dir / "lab_form.txt").read_text().strip()
     assert r.text == expected
+
+
+@pytest.mark.asyncio
+async def test_errors(client: AsyncClient) -> None:
+    r = await client.get(
+        "/nublado/spawner/v1/lab-form/someuser",
+        headers={"X-Auth-Request-User": "otheruser"},
+    )
+    assert r.status_code == 403
+    assert r.json() == {
+        "detail": [{"msg": "Permission denied", "type": "permission_denied"}]
+    }

--- a/tests/handlers/labs_test.py
+++ b/tests/handlers/labs_test.py
@@ -65,11 +65,29 @@ async def test_lab_start_stop(
     assert r.json() == []
     r = await client.get(f"/nublado/spawner/v1/labs/{user.username}")
     assert r.status_code == 404
+    assert r.json() == {
+        "detail": [
+            {
+                "loc": ["path", "username"],
+                "msg": f"Unknown user {user.username}",
+                "type": "unknown_user",
+            }
+        ]
+    }
     r = await client.get(
         f"/nublado/spawner/v1/labs/{user.username}/events",
         headers={"X-Auth-Request-User": user.username},
     )
     assert r.status_code == 404
+    assert r.json() == {
+        "detail": [
+            {
+                "loc": ["path", "username"],
+                "msg": f"Unknown user {user.username}",
+                "type": "unknown_user",
+            }
+        ]
+    }
 
     # Create a lab.
     r = await client.post(

--- a/tests/handlers/labs_test.py
+++ b/tests/handlers/labs_test.py
@@ -409,3 +409,26 @@ async def test_errors(
             }
         ]
     }
+
+    # Test asking for an image that doesn't exist.
+    r = await client.post(
+        f"/nublado/spawner/v1/labs/{user.username}/create",
+        json={
+            "options": {"image_tag": "unknown", "size": "small"},
+            "env": lab.env,
+        },
+        headers={
+            "X-Auth-Request-Token": token,
+            "X-Auth-Request-User": user.username,
+        },
+    )
+    assert r.status_code == 400
+    assert r.json() == {
+        "detail": [
+            {
+                "loc": ["body", "options", "image_tag"],
+                "msg": 'Docker tag "unknown" not found',
+                "type": "unknown_image",
+            }
+        ]
+    }

--- a/tests/handlers/labs_test.py
+++ b/tests/handlers/labs_test.py
@@ -349,6 +349,20 @@ async def test_errors(
         "detail": [{"msg": "Permission denied", "type": "permission_denied"}]
     }
 
+    # Invalid token.
+    r = await client.post(
+        "/nublado/spawner/v1/labs/otheruser/create",
+        json={"options": lab.options.dict(), "env": lab.env},
+        headers={
+            "X-Auth-Request-Token": "some-invalid-token",
+            "X-Auth-Request-User": user.username,
+        },
+    )
+    assert r.status_code == 401
+    assert r.json() == {
+        "detail": [{"msg": "User token is invalid", "type": "invalid_token"}]
+    }
+
     # Test passing a reference with no tag.
     options = lab.options.dict()
     options["image_list"] = "lighthouse.ceres/library/sketchbook"

--- a/tests/handlers/labs_test.py
+++ b/tests/handlers/labs_test.py
@@ -146,6 +146,25 @@ async def test_lab_start_stop(
         "username": user.username,
     }
 
+    # Creating the lab again should result in a 409 error.
+    r = await client.post(
+        f"/nublado/spawner/v1/labs/{user.username}/create",
+        json={"options": lab.options.dict(), "env": lab.env},
+        headers={
+            "X-Auth-Request-Token": token,
+            "X-Auth-Request-User": user.username,
+        },
+    )
+    assert r.status_code == 409
+    assert r.json() == {
+        "detail": [
+            {
+                "msg": f"Lab already exists for {user.username}",
+                "type": "lab_exists",
+            }
+        ]
+    }
+
     # Stop the lab.
     r = await client.delete(f"/nublado/spawner/v1/labs/{user.username}")
     assert r.status_code == 204

--- a/tests/handlers/labs_test.py
+++ b/tests/handlers/labs_test.py
@@ -291,6 +291,28 @@ async def test_errors(
     token, user = obj_factory.get_user()
     lab = obj_factory.labspecs[0]
 
+    # Wrong user.
+    r = await client.post(
+        "/nublado/spawner/v1/labs/otheruser/create",
+        json={"options": lab.options.dict(), "env": lab.env},
+        headers={
+            "X-Auth-Request-Token": token,
+            "X-Auth-Request-User": user.username,
+        },
+    )
+    assert r.status_code == 403
+    assert r.json() == {
+        "detail": [{"msg": "Permission denied", "type": "permission_denied"}]
+    }
+    r = await client.get(
+        "/nublado/spawner/v1/labs/otheruser/events",
+        headers={"X-Auth-Request-User": user.username},
+    )
+    assert r.status_code == 403
+    assert r.json() == {
+        "detail": [{"msg": "Permission denied", "type": "permission_denied"}]
+    }
+
     # Test passing a reference with no tag.
     options = lab.options.dict()
     options["image_list"] = "lighthouse.ceres/library/sketchbook"

--- a/tests/handlers/user_status_test.py
+++ b/tests/handlers/user_status_test.py
@@ -22,12 +22,14 @@ async def test_user_status(
     # At the start, we shouldn't have any lab.
     r = await client.get(
         "/nublado/spawner/v1/user-status",
-        headers={
-            "X-Auth-Request-Token": token,
-            "X-Auth-Request-User": user.username,
-        },
+        headers={"X-Auth-Request-User": user.username},
     )
     assert r.status_code == 404
+    assert r.json() == {
+        "detail": [
+            {"msg": f"Unknown user {user.username}", "type": "unknown_user"}
+        ]
+    }
 
     # Create a lab.
     r = await client.post(
@@ -52,10 +54,7 @@ async def test_user_status(
     # Now the lab should exist and we should be able to get some user status.
     r = await client.get(
         "/nublado/spawner/v1/user-status",
-        headers={
-            "X-Auth-Request-Token": token,
-            "X-Auth-Request-User": user.username,
-        },
+        headers={"X-Auth-Request-User": user.username},
     )
     assert r.status_code == 200
     expected_resources = size_manager.resources(lab.options.size)


### PR DESCRIPTION
Previously, the handlers were checking for expected errors and turning them manually into `HTTPException` exceptions. The detail part of those exceptions was generally just a string, rather than the error model the API specification claimed we were using, and each new exception had to be manually caught.

Import an idea from Gafaelfawr where there is a top-level exception class with a global exception handler that understands how to format itself into the error model using class variables that can be set by subclassed exceptions to indicate things like the error code and the HTTP status. Convert all the expected exceptions that should result in normal error codes (not a 500) to be based on that exception class. Annotate the exceptions on the way through with location information about the input that caused the error, where appropriate.