### PR TITLE
DM-38554: Switch to JSON events

### DIFF
--- a/src/jupyterlabcontroller/services/events.py
+++ b/src/jupyterlabcontroller/services/events.py
@@ -106,7 +106,7 @@ class EventManager:
         events = self._events[username]
         del self._events[username]
         if not events or not events[-1].done:
-            event = Event(data="Operation aborted", type=EventType.FAILED)
+            event = Event(message="Operation aborted", type=EventType.FAILED)
             events.append(event)
         triggers = self._triggers[username]
         del self._triggers[username]

--- a/src/jupyterlabcontroller/services/lab.py
+++ b/src/jupyterlabcontroller/services/lab.py
@@ -96,20 +96,14 @@ class LabManager:
         return r is not None
 
     async def info_event(self, username: str, message: str, pct: int) -> None:
-        if pct < 0 or pct > 100:
-            raise RuntimeError(
-                "% completion must be between 0 and 100 inclusive"
-            )
-        event = Event(data=str(pct), type=EventType.PROGRESS)
-        self.event_manager.publish_event(username, event)
         umsg = f"{message} for {username}"
-        event = Event(data=umsg, type=EventType.INFO)
+        event = Event(message=umsg, progress=pct, type=EventType.INFO)
         self.event_manager.publish_event(username, event)
         self.logger.info(f"Event: {umsg}: {pct}%")
 
     async def completion_event(self, username: str) -> None:
         cstr = f"Operation complete for {username}"
-        event = Event(data=cstr, type=EventType.COMPLETE)
+        event = Event(message=cstr, type=EventType.COMPLETE)
         self.event_manager.publish_event(username, event)
         self.logger.info(cstr)
 
@@ -117,11 +111,11 @@ class LabManager:
         self, username: str, message: str, fatal: bool = True
     ) -> None:
         umsg = message + f" for {username}"
-        event = Event(data=umsg, type=EventType.ERROR)
+        event = Event(message=umsg, type=EventType.ERROR)
         self.event_manager.publish_event(username, event)
         if fatal:
             event = Event(
-                data=f"Lab creation failed for {username}",
+                message=f"Lab creation failed for {username}",
                 type=EventType.FAILED,
             )
             self.event_manager.publish_event(username, event)

--- a/tests/configs/standard/output/pod-events.json
+++ b/tests/configs/standard/output/pod-events.json
@@ -1,94 +1,50 @@
 [
   {
-    "data": "2",
-    "event": "progress"
-  },
-  {
-    "data": "Lab creation initiated for rachel",
+    "data": "{\"message\": \"Lab creation initiated for rachel\", \"progress\": 2}",
     "event": "info"
   },
   {
-    "data": "5",
-    "event": "progress"
-  },
-  {
-    "data": "User namespace created for rachel",
+    "data": "{\"message\": \"User namespace created for rachel\", \"progress\": 5}",
     "event": "info"
   },
   {
-    "data": "10",
-    "event": "progress"
-  },
-  {
-    "data": "Secrets created for rachel",
+    "data": "{\"message\": \"Secrets created for rachel\", \"progress\": 10}",
     "event": "info"
   },
   {
-    "data": "15",
-    "event": "progress"
-  },
-  {
-    "data": "NSS files created for rachel",
+    "data": "{\"message\": \"NSS files created for rachel\", \"progress\": 15}",
     "event": "info"
   },
   {
-    "data": "20",
-    "event": "progress"
-  },
-  {
-    "data": "Config files created for rachel",
+    "data": "{\"message\": \"Config files created for rachel\", \"progress\": 20}",
     "event": "info"
   },
   {
-    "data": "25",
-    "event": "progress"
-  },
-  {
-    "data": "Environment created for rachel",
+    "data": "{\"message\": \"Environment created for rachel\", \"progress\": 25}",
     "event": "info"
   },
   {
-    "data": "25",
-    "event": "progress"
-  },
-  {
-    "data": "Network policy created for rachel",
+    "data": "{\"message\": \"Network policy created for rachel\", \"progress\": 25}",
     "event": "info"
   },
   {
-    "data": "30",
-    "event": "progress"
-  },
-  {
-    "data": "Quota created for rachel",
+    "data": "{\"message\": \"Quota created for rachel\", \"progress\": 30}",
     "event": "info"
   },
   {
-    "data": "35",
-    "event": "progress"
-  },
-  {
-    "data": "Service created for rachel",
+    "data": "{\"message\": \"Service created for rachel\", \"progress\": 35}",
     "event": "info"
   },
   {
-    "data": "40",
-    "event": "progress"
-  },
-  {
-    "data": "Resource objects created for rachel",
+    "data": "{\"message\": \"Resource objects created for rachel\", \"progress\": 40}",
     "event": "info"
   },
   {
-    "data": "45",
-    "event": "progress"
-  },
-  {
-    "data": "Pod requested for rachel",
+    "data": "{\"message\": \"Pod requested for rachel\", \"progress\": 45}",
     "event": "info"
   },
   {
-    "data": "Operation complete for rachel",
+    "data": "{\"message\": \"Operation complete for rachel\"}",
     "event": "complete"
   }
 ]

--- a/tests/handlers/labs_test.py
+++ b/tests/handlers/labs_test.py
@@ -260,19 +260,39 @@ async def test_delayed_spawn(
     expected_events = (
         expected_events[:-1]
         + [
-            {"data": "46", "event": "progress"},
             {
-                "data": f"Autoscaling cluster for reasons for {user.username}",
+                "data": json.dumps(
+                    {
+                        "message": (
+                            "Autoscaling cluster for reasons for"
+                            f" {user.username}"
+                        ),
+                        "progress": 46,
+                    }
+                ),
                 "event": "info",
             },
-            {"data": "60", "event": "progress"},
             {
-                "data": f"Mounting all the things for {user.username}",
+                "data": json.dumps(
+                    {
+                        "message": (
+                            f"Mounting all the things for {user.username}"
+                        ),
+                        "progress": 60,
+                    }
+                ),
                 "event": "info",
             },
-            {"data": "69", "event": "progress"},
             {
-                "data": f"Pod nb-{user.username} started for {user.username}",
+                "data": json.dumps(
+                    {
+                        "message": (
+                            f"Pod nb-{user.username} started for"
+                            f" {user.username}"
+                        ),
+                        "progress": 69,
+                    }
+                ),
                 "event": "info",
             },
         ]


### PR DESCRIPTION
My original idea to use separate events for progress and messages to avoid adding another encoding layer turned out to be a poor one. This required worrying about the ordering of messages and more complex logic on both sides, and the httpx-sse library supports decoding a JSON body of a server-sent event. Switch to JSON-encoded messages that include both a message and an optional progress value.