### PR TITLE
DM-38554: Update pod state in user status during spawn

### DIFF
--- a/src/jupyterlabcontroller/models/domain/usermap.py
+++ b/src/jupyterlabcontroller/models/domain/usermap.py
@@ -1,6 +1,6 @@
 """Event model for jupyterlab-controller."""
 
-from ..v1.lab import LabStatus, UserData
+from ..v1.lab import LabStatus, PodState, UserData
 
 
 class UserMap:
@@ -15,6 +15,9 @@ class UserMap:
 
     def set(self, key: str, item: UserData) -> None:
         self._dict[key] = item
+
+    def set_pod_state(self, key: str, pod_state: PodState) -> None:
+        self._dict[key].pod = pod_state
 
     def set_status(self, key: str, status: LabStatus) -> None:
         self._dict[key].status = status

--- a/src/jupyterlabcontroller/services/lab.py
+++ b/src/jupyterlabcontroller/services/lab.py
@@ -46,6 +46,7 @@ from ..models.v1.event import Event, EventType
 from ..models.v1.lab import (
     LabSpecification,
     LabStatus,
+    PodState,
     UserData,
     UserInfo,
     UserResourceQuantum,
@@ -234,6 +235,7 @@ class LabManager:
         await self.info_event(username, "Resource objects created", 40)
         resources = self._size_manager.resources(lab.options.size)
         await self.create_user_pod(user, resources, image)
+        self.user_map.set_pod_state(username, PodState.PRESENT)
         self.user_map.set_status(username, status=LabStatus.PENDING)
         # We need to set the expected internal URL, because the spawner
         # start needs to know it, even though it's not accessible yet.

--- a/tests/handlers/labs_test.py
+++ b/tests/handlers/labs_test.py
@@ -139,7 +139,7 @@ async def test_lab_start_stop(
         "name": user.name,
         "options": expected_options,
         "quota": None,
-        "pod": "missing",
+        "pod": "present",
         "resources": expected_resources.dict(),
         "status": "running",
         "uid": user.uid,

--- a/tests/handlers/user_status_test.py
+++ b/tests/handlers/user_status_test.py
@@ -67,7 +67,7 @@ async def test_user_status(
         "name": user.name,
         "options": lab.options.dict(),
         "quota": None,
-        "pod": "missing",
+        "pod": "present",
         "resources": expected_resources.dict(),
         "status": "running",
         "uid": user.uid,


### PR DESCRIPTION
This is a temporary hack so that the pod state is not completely wrong. The status request should check to see if the pod is there rather than just trusting it is based on internal state, but that's not a release blocker and thus a problem for another day.