### PR TITLE
DM-38554: Improvements to lab spawn messages

### DIFF
--- a/tests/configs/standard/output/pod-events.json
+++ b/tests/configs/standard/output/pod-events.json
@@ -1,50 +1,22 @@
 [
   {
-    "data": "{\"message\": \"Lab creation initiated for rachel\", \"progress\": 2}",
+    "data": "{\"message\": \"Starting lab creation for rachel\", \"progress\": 2}",
     "event": "info"
   },
   {
-    "data": "{\"message\": \"User namespace created for rachel\", \"progress\": 5}",
+    "data": "{\"message\": \"Created user namespace\", \"progress\": 5}",
     "event": "info"
   },
   {
-    "data": "{\"message\": \"Secrets created for rachel\", \"progress\": 10}",
+    "data": "{\"message\": \"Created Kubernetes resources for lab\", \"progress\": 25}",
     "event": "info"
   },
   {
-    "data": "{\"message\": \"NSS files created for rachel\", \"progress\": 15}",
+    "data": "{\"message\": \"Requested lab Kubernetes pod\", \"progress\": 30}",
     "event": "info"
   },
   {
-    "data": "{\"message\": \"Config files created for rachel\", \"progress\": 20}",
-    "event": "info"
-  },
-  {
-    "data": "{\"message\": \"Environment created for rachel\", \"progress\": 25}",
-    "event": "info"
-  },
-  {
-    "data": "{\"message\": \"Network policy created for rachel\", \"progress\": 25}",
-    "event": "info"
-  },
-  {
-    "data": "{\"message\": \"Quota created for rachel\", \"progress\": 30}",
-    "event": "info"
-  },
-  {
-    "data": "{\"message\": \"Service created for rachel\", \"progress\": 35}",
-    "event": "info"
-  },
-  {
-    "data": "{\"message\": \"Resource objects created for rachel\", \"progress\": 40}",
-    "event": "info"
-  },
-  {
-    "data": "{\"message\": \"Pod requested for rachel\", \"progress\": 45}",
-    "event": "info"
-  },
-  {
-    "data": "{\"message\": \"Operation complete for rachel\"}",
+    "data": "{\"message\": \"Lab Kubernetes pod started for rachel\"}",
     "event": "complete"
   }
 ]

--- a/tests/handlers/labs_test.py
+++ b/tests/handlers/labs_test.py
@@ -118,7 +118,7 @@ async def test_lab_start_stop(
         headers={"X-Auth-Request-User": user.username},
     )
     assert r.status_code == 200
-    assert f"Operation complete for {user.username}" in r.text
+    assert "Lab Kubernetes pod started" in r.text
 
     # The user's lab should now be visible.
     r = await client.get("/nublado/spawner/v1/labs")
@@ -263,11 +263,8 @@ async def test_delayed_spawn(
             {
                 "data": json.dumps(
                     {
-                        "message": (
-                            "Autoscaling cluster for reasons for"
-                            f" {user.username}"
-                        ),
-                        "progress": 46,
+                        "message": "Autoscaling cluster for reasons",
+                        "progress": 35,
                     }
                 ),
                 "event": "info",
@@ -275,10 +272,8 @@ async def test_delayed_spawn(
             {
                 "data": json.dumps(
                     {
-                        "message": (
-                            f"Mounting all the things for {user.username}"
-                        ),
-                        "progress": 60,
+                        "message": "Mounting all the things",
+                        "progress": 48,
                     }
                 ),
                 "event": "info",
@@ -286,11 +281,8 @@ async def test_delayed_spawn(
             {
                 "data": json.dumps(
                     {
-                        "message": (
-                            f"Pod nb-{user.username} started for"
-                            f" {user.username}"
-                        ),
-                        "progress": 69,
+                        "message": f"Pod nb-{user.username} started",
+                        "progress": 57,
                     }
                 ),
                 "event": "info",


### PR DESCRIPTION
Sending separate progress events for the creation of every type of object spams the event list and tends to push the interesting events towards or off the bottom of the screen. Since all those events are identical every time, only emit events for creating the namespace and the supporting resources.

Tweak the percentages based on my subjective impression of what steps take the most time, leaving more room for the pod spawning itself. Use 75% as the threshold at which we hand control back to JupyterHub and wait for the lab to start.

Remove the username from every progress message. Since the progress messages are only returned by calling a user-specific endpoint, this seems pointless. Instead, only mention the user in the first and last messages.