### PR TITLE
DM-38554: Reduce severity of state recreation log message

### DIFF
--- a/src/jupyterlabcontroller/services/lab.py
+++ b/src/jupyterlabcontroller/services/lab.py
@@ -965,12 +965,14 @@ class LabManager:
                     else:
                         self.logger.warning("Updating user map")
                         user_map.set_status(user, status=obs_rec.status)
+
         # Second pass: take observed state and create any missing user map
-        # entries
+        # entries. This is the normal case after a restart of the lab
+        # controller.
         for user in obs_users:
             obs_rec = observed_state[user]
             if user not in known_users:
-                self.logger.warning(
+                self.logger.info(
                     f"No entry for observed user '{user}' in user "
                     + "map.  Creating record from observation"
                 )


### PR DESCRIPTION
When reconstructing internal state from Kubernetes after a restart, it's normal to encounter user labs that are not present in the internal state. Log this at info level rather than warning.