### PR TITLE
DM-38554: Do not include Gafaelfawr headers in schema

### DIFF
--- a/src/jupyterlabcontroller/handlers/form.py
+++ b/src/jupyterlabcontroller/handlers/form.py
@@ -21,7 +21,7 @@ __all__ = ["router"]
 )
 async def get_user_lab_form(
     username: str,
-    x_auth_request_user: str = Header(...),
+    x_auth_request_user: str = Header(..., include_in_schema=False),
     context: RequestContext = Depends(context_dependency),
 ) -> str:
     if username != x_auth_request_user:

--- a/src/jupyterlabcontroller/handlers/labs.py
+++ b/src/jupyterlabcontroller/handlers/labs.py
@@ -64,7 +64,7 @@ async def post_new_lab(
     username: str,
     lab: LabSpecification,
     response: Response,
-    x_auth_request_token: str = Header(...),
+    x_auth_request_token: str = Header(..., include_in_schema=False),
     context: RequestContext = Depends(context_dependency),
 ) -> None:
     gafaelfawr_client = context.factory.create_gafaelfawr_client()
@@ -122,7 +122,7 @@ async def delete_user_lab(
 )
 async def get_user_events(
     username: str,
-    x_auth_request_user: str = Header(...),
+    x_auth_request_user: str = Header(..., include_in_schema=False),
     context: RequestContext = Depends(context_dependency),
 ) -> EventSourceResponse:
     """Returns the events for the lab of the given user"""

--- a/src/jupyterlabcontroller/handlers/user_status.py
+++ b/src/jupyterlabcontroller/handlers/user_status.py
@@ -20,7 +20,7 @@ __all__ = ["router"]
     response_model=UserData,
 )
 async def get_user_status(
-    x_auth_request_user: str = Header(...),
+    x_auth_request_user: str = Header(..., include_in_schema=False),
     context: RequestContext = Depends(context_dependency),
 ) -> UserData:
     userdata = context.user_map.get(x_auth_request_user)


### PR DESCRIPTION
Various routes of the lab controller pull information from the X-Auth-Request-User and X-Auth-Request-Token headers, set by Gafaelfawr. By default, FastAPI includes that in the OpenAPI schema, but in this case this is an internal implementation detail of our authentication system and the client should never send these headers. Mark them as not included in the schema.