### PR TITLE
DM-38554: Add ownership information to prepull pods

### DIFF
--- a/src/jupyterlabcontroller/config.py
+++ b/src/jupyterlabcontroller/config.py
@@ -12,7 +12,7 @@ from pydantic import BaseSettings, Field, validator
 from safir.logging import LogLevel, Profile
 from safir.pydantic import CamelCaseModel, to_camel_case
 
-from .constants import DOCKER_SECRETS_PATH
+from .constants import DOCKER_SECRETS_PATH, METADATA_PATH
 from .models.v1.lab import LabSize
 from .models.v1.prepuller_config import PrepullerConfig
 
@@ -274,6 +274,17 @@ class Config(BaseSettings):
     )
     docker_secrets_path: Path = Field(
         DOCKER_SECRETS_PATH, title="Path to Docker API credentials"
+    )
+    metadata_path: Path = Field(
+        METADATA_PATH,
+        title="Path to injected pod metadata",
+        description=(
+            "This directory should contain files named `name` and `uid`, which"
+            " should contain the name and UUID of the lab controller pod,"
+            " respectively. (Normally this is done via the Kubernetes"
+            " `downwardAPI`.) These are used to set ownership information on"
+            " pods spawned by the prepuller."
+        ),
     )
 
     # CamelCaseModel conflicts with BaseSettings, so do this manually.

--- a/src/jupyterlabcontroller/constants.py
+++ b/src/jupyterlabcontroller/constants.py
@@ -9,6 +9,9 @@ CONFIGURATION_PATH = Path("/etc/nublado/config.yaml")
 DOCKER_SECRETS_PATH = Path("/etc/secrets/.dockerconfigjson")
 """Default path to the Docker API secrets."""
 
+METADATA_PATH = Path("/etc/podinfo")
+"""Default path to injected pod metadata."""
+
 IMAGE_REFRESH_INTERVAL = timedelta(minutes=5)
 """How frequently to refresh the list of remote and cached images."""
 

--- a/src/jupyterlabcontroller/factory.py
+++ b/src/jupyterlabcontroller/factory.py
@@ -125,11 +125,12 @@ class ProcessContext:
         return cls(
             config=config,
             http_client=http_client,
+            image_service=image_service,
             k8s_api_client=k8s_api_client,
             k8s_client=k8s_client,
-            image_service=image_service,
             prepuller=Prepuller(
                 namespace=config.lab.namespace_prefix,
+                metadata_path=config.metadata_path,
                 image_service=image_service,
                 k8s_client=k8s_client,
                 logger=logger,
@@ -250,6 +251,13 @@ class Factory:
         )
 
     def create_form_manager(self) -> FormManager:
+        """Create service to generate lab spawning forms.
+
+        Returns
+        -------
+        FormManager
+            Newly-created form manager.
+        """
         return FormManager(
             image_service=self._context.image_service,
             lab_sizes=self._context.config.lab.sizes,
@@ -257,6 +265,13 @@ class Factory:
         )
 
     def create_gafaelfawr_client(self) -> GafaelfawrStorageClient:
+        """Create client to look up users in Gafaelfawr.
+
+        Returns
+        -------
+        GafaelfawrStorageClient
+            Newly-created Gafaelfawr client.
+        """
         return GafaelfawrStorageClient(
             config=self._context.config,
             http_client=self._context.http_client,
@@ -264,6 +279,13 @@ class Factory:
         )
 
     def create_lab_manager(self) -> LabManager:
+        """Create service to manage user labs.
+
+        Returns
+        -------
+        LabManager
+            Newly-creted lab manager.
+        """
         size_manager = self.create_size_manager()
         return LabManager(
             instance_url=self._context.config.base_url,
@@ -278,6 +300,13 @@ class Factory:
         )
 
     def create_size_manager(self) -> SizeManager:
+        """Create service to map between named sizes and resource amounts.
+
+        Returns
+        -------
+        SizeManager
+            Newly-created size manager.
+        """
         return SizeManager(self._context.config.lab.sizes)
 
     def set_logger(self, logger: BoundLogger) -> None:

--- a/src/jupyterlabcontroller/storage/k8s.py
+++ b/src/jupyterlabcontroller/storage/k8s.py
@@ -18,6 +18,7 @@ from kubernetes_asyncio.client.models import (
     V1NetworkPolicyPort,
     V1NetworkPolicySpec,
     V1ObjectMeta,
+    V1OwnerReference,
     V1Pod,
     V1PodSpec,
     V1ResourceQuota,
@@ -469,11 +470,15 @@ class K8sStorageClient:
         name: str,
         namespace: str,
         pod_spec: V1PodSpec,
+        *,
         labels: Optional[dict[str, str]] = None,
+        owner: Optional[V1OwnerReference] = None,
     ) -> None:
         metadata = self._standard_metadata(name)
         if labels:
             metadata.labels.update(labels)
+        if owner:
+            metadata.owner_references = [owner]
         pod = V1Pod(metadata=metadata, spec=pod_spec)
         try:
             await self.api.create_namespaced_pod(namespace, pod)

--- a/tests/configs/standard/input/metadata/name
+++ b/tests/configs/standard/input/metadata/name
@@ -1,0 +1,1 @@
+nublado-controller

--- a/tests/configs/standard/input/metadata/uid
+++ b/tests/configs/standard/input/metadata/uid
@@ -1,0 +1,1 @@
+12720beb-ecae-452e-982e-2f0a0a2fbaf1

--- a/tests/configs/standard/output/prepull-objects.json
+++ b/tests/configs/standard/output/prepull-objects.json
@@ -11,7 +11,16 @@
         "argocd.argoproj.io/instance": "nublado-users"
       },
       "name": "prepull-d-2077-10-23-node2",
-      "namespace": "userlabs"
+      "namespace": "userlabs",
+      "owner_references": [
+        {
+          "api_version": "v1",
+          "block_owner_deletion": true,
+          "kind": "Pod",
+          "name": "nublado-controller",
+          "uid": "12720beb-ecae-452e-982e-2f0a0a2fbaf1"
+        }
+      ]
     },
     "spec": {
       "containers": [

--- a/tests/services/prepuller_test.py
+++ b/tests/services/prepuller_test.py
@@ -152,7 +152,9 @@ async def test_gar(
         expected = read_output_data("gar", "menu-before.json")
         assert seen == expected
 
-        # There should be two running pods, one for each node.
+        # There should be two running pods, one for each node. Since we didn't
+        # configure any pod metadata, they should also not have owner
+        # references.
         namespace = config.lab.namespace_prefix
         pod_list = await mock_kubernetes.list_namespaced_pod(namespace)
         tag = known_images[0]["tags"][0].replace("_", "-")
@@ -160,6 +162,7 @@ async def test_gar(
             f"prepull-{tag}-node1",
             f"prepull-{tag}-node2",
         ]
+        assert all([not p.metadata.owner_references for p in pod_list.items])
 
         # Mark those nodes as complete, and two more should be started.
         for pod in pod_list.items:

--- a/tests/support/config.py
+++ b/tests/support/config.py
@@ -29,4 +29,5 @@ def configure(directory: str) -> Config:
     config = configuration_dependency.config
     if (config_path / "docker_config.json").exists():
         config.docker_secrets_path = config_path / "docker_config.json"
+    config.metadata_path = config_path / "metadata"
     return configuration_dependency.config


### PR DESCRIPTION
Use the injected pod metadata for the lab controller to mark the prepull pods as owned by the lab controller. Set block owner deletion to try to force cleanup of the prepull pods before restarting the lab controller, to reduce conflicts after restart.