### PR TITLE
DM-38554: Fix cycle handling with Google Artifact Registry

### DIFF
--- a/src/jupyterlabcontroller/services/source/gar.py
+++ b/src/jupyterlabcontroller/services/source/gar.py
@@ -180,7 +180,7 @@ class GARImageSource(ImageSource):
         RSPImageCollection
             New collection of images to prepull.
         """
-        images = await self._gar.list_images(self._config)
+        images = await self._gar.list_images(self._config, prepull.cycle)
 
         # Set their node presence information based on node cache data.
         for node, node_images in node_cache.items():

--- a/src/jupyterlabcontroller/storage/gar.py
+++ b/src/jupyterlabcontroller/storage/gar.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Optional
+
 from google.cloud import artifactregistry_v1
 from google.cloud.artifactregistry_v1 import ListDockerImagesRequest
 from structlog.stdlib import BoundLogger
@@ -30,13 +32,17 @@ class GARStorageClient:
         self._logger = logger
         self._client = artifactregistry_v1.ArtifactRegistryAsyncClient()
 
-    async def list_images(self, config: GARSourceConfig) -> RSPImageCollection:
+    async def list_images(
+        self, config: GARSourceConfig, cycle: Optional[int] = None
+    ) -> RSPImageCollection:
         """Return all images stored in the remote repository.
 
         Parameters
         ----------
         config
             Path to a specific image name in Google Artifact Registry.
+        cycle
+            If not `None`, restrict to images with the given SAL cycle.
 
         Returns
         -------
@@ -60,4 +66,4 @@ class GARStorageClient:
                 image.size = gar_image.image_size_bytes
                 images.append(image)
 
-        return RSPImageCollection(images)
+        return RSPImageCollection(images, cycle=cycle)

--- a/tests/configs/gar-cycle/input/config.yaml
+++ b/tests/configs/gar-cycle/input/config.yaml
@@ -1,0 +1,20 @@
+safir:
+  profile: development
+  logLevel: DEBUG
+lab:
+  sizes:
+    small:
+      cpu: 1.0
+      memory: 3Gi
+images:
+  source:
+    type: google
+    location: us-central1
+    projectId: lighthouse-71ec
+    repository: library
+    image: sketchbook
+  recommendedTag: recommended_c0050
+  numReleases: 0
+  numWeeklies: 3
+  numDailies: 0
+  cycle: 50

--- a/tests/configs/gar-cycle/input/known-images.json
+++ b/tests/configs/gar-cycle/input/known-images.json
@@ -1,0 +1,102 @@
+[
+  {
+    "name": "projects/lighthouse-71ec/locations/us-central1/repositories/library/dockerImages/sketchbook@sha256:dd6d876548037ec722252b45795206575e7040eba1ca076cf1732a4a903cadba",
+    "uri": "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook@sha256:dd6d876548037ec722252b45795206575e7040eba1ca076cf1732a4a903cadba",
+    "tags": ["recommended"],
+    "image_size_bytes": 123456,
+    "upload_time": "2023-03-27T13:02:39Z",
+    "media_type": "application/vnd.docker.distribution.manifest.v2+json",
+    "build_time": "2023-03-27T13:02:39Z",
+    "update_time": "2023-03-27T13:02:39Z"
+  },
+  {
+    "name": "projects/lighthouse-71ec/locations/us-central1/repositories/library/dockerImages/sketchbook@sha256:49d63632237c3c0ca10c2c8de1e4310acadea2cdf2f9eaed0e2d2c0c27736c0b",
+    "uri": "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook@sha256:49d63632237c3c0ca10c2c8de1e4310acadea2cdf2f9eaed0e2d2c0c27736c0b",
+    "tags": ["recommended_c0050", "w_2077_43_c0050.002"],
+    "image_size_bytes": 123456,
+    "upload_time": "2023-03-27T13:02:39Z",
+    "media_type": "application/vnd.docker.distribution.manifest.v2+json",
+    "build_time": "2023-03-27T13:02:39Z",
+    "update_time": "2023-03-27T13:02:39Z"
+  },
+  {
+    "name": "projects/lighthouse-71ec/locations/us-central1/repositories/library/dockerImages/sketchbook@sha256:b14b81ae38caa6c6d919fc02c202b5d2a99dcce0d4c16ee6ad08b3831e814403",
+    "uri": "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook@sha256:b14b81ae38caa6c6d919fc02c202b5d2a99dcce0d4c16ee6ad08b3831e814403",
+    "tags": ["latest_c0050", "w_2077_43_c0050.004"],
+    "image_size_bytes": 123456,
+    "upload_time": "2023-03-27T13:02:39Z",
+    "media_type": "application/vnd.docker.distribution.manifest.v2+json",
+    "build_time": "2023-03-27T13:02:39Z",
+    "update_time": "2023-03-27T13:02:39Z"
+  },
+  {
+    "name": "projects/lighthouse-71ec/locations/us-central1/repositories/library/dockerImages/sketchbook@sha256:ae673b901072c45e646d4af329a63c8742604b77c29523d056c0522ca702f4ce",
+    "uri": "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook@sha256:ae673b901072c45e646d4af329a63c8742604b77c29523d056c0522ca702f4ce",
+    "tags": ["w_2077_44"],
+    "image_size_bytes": 123456,
+    "upload_time": "2023-03-27T13:02:39Z",
+    "media_type": "application/vnd.docker.distribution.manifest.v2+json",
+    "build_time": "2023-03-27T13:02:39Z",
+    "update_time": "2023-03-27T13:02:39Z"
+  },
+  {
+    "name": "projects/lighthouse-71ec/locations/us-central1/repositories/library/dockerImages/sketchbook@sha256:46907aca9d3b972d17220e105a45a44aa0c49bf39c424dd659055ffa2d63c9f0",
+    "uri": "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook@sha256:46907aca9d3b972d17220e105a45a44aa0c49bf39c424dd659055ffa2d63c9f0",
+    "tags": ["w_2077_44_c0051.001"],
+    "image_size_bytes": 123456,
+    "upload_time": "2023-03-27T13:02:39Z",
+    "media_type": "application/vnd.docker.distribution.manifest.v2+json",
+    "build_time": "2023-03-27T13:02:39Z",
+    "update_time": "2023-03-27T13:02:39Z"
+  },
+  {
+    "name": "projects/lighthouse-71ec/locations/us-central1/repositories/library/dockerImages/sketchbook@sha256:9401f5d181180167d2a2b1d111456a4b9b506245bc43da8c4c869a87d512ecda",
+    "uri": "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook@sha256:9401f5d181180167d2a2b1d111456a4b9b506245bc43da8c4c869a87d512ecda",
+    "tags": ["w_2077_43_c0050.003"],
+    "image_size_bytes": 123456,
+    "upload_time": "2023-03-27T13:02:39Z",
+    "media_type": "application/vnd.docker.distribution.manifest.v2+json",
+    "build_time": "2023-03-27T13:02:39Z",
+    "update_time": "2023-03-27T13:02:39Z"
+  },
+  {
+    "name": "projects/lighthouse-71ec/locations/us-central1/repositories/library/dockerImages/sketchbook@sha256:7d890dd00b7677de625d579e7927ff05e0fb009ef54fe66850288b845d33c1f6",
+    "uri": "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook@sha256:7d890dd00b7677de625d579e7927ff05e0fb009ef54fe66850288b845d33c1f6",
+    "tags": ["w_2077_43_c0050.001"],
+    "image_size_bytes": 123456,
+    "upload_time": "2023-03-27T13:02:39Z",
+    "media_type": "application/vnd.docker.distribution.manifest.v2+json",
+    "build_time": "2023-03-27T13:02:39Z",
+    "update_time": "2023-03-27T13:02:39Z"
+  },
+  {
+    "name": "projects/lighthouse-71ec/locations/us-central1/repositories/library/dockerImages/sketchbook@sha256:862d951e25b2e47a6bd85f000ef0fd4b4e95ebaec4d63ea89baaf79f0665cd4b",
+    "uri": "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook@sha256:862d951e25b2e47a6bd85f000ef0fd4b4e95ebaec4d63ea89baaf79f0665cd4b",
+    "tags": ["w_2077_45_c0049.001"],
+    "image_size_bytes": 123456,
+    "upload_time": "2023-03-27T13:02:39Z",
+    "media_type": "application/vnd.docker.distribution.manifest.v2+json",
+    "build_time": "2023-03-27T13:02:39Z",
+    "update_time": "2023-03-27T13:02:39Z"
+  },
+  {
+    "name": "projects/lighthouse-71ec/locations/us-central1/repositories/library/dockerImages/sketchbook@sha256:9c57a60107e99e7a6cfcf395c26ff3bdabd3a92e88dabe3b5f1974326c7e991a",
+    "uri": "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook@sha256:9c57a60107e99e7a6cfcf395c26ff3bdabd3a92e88dabe3b5f1974326c7e991a",
+    "tags": ["exp_w_2077_41_c0050.002_testing"],
+    "image_size_bytes": 123456,
+    "upload_time": "2023-03-27T13:02:39Z",
+    "media_type": "application/vnd.docker.distribution.manifest.v2+json",
+    "build_time": "2023-03-27T13:02:39Z",
+    "update_time": "2023-03-27T13:02:39Z"
+  },
+  {
+    "name": "projects/lighthouse-71ec/locations/us-central1/repositories/library/dockerImages/sketchbook@sha256:737704b79369f336c8c05b4b28fd2da0e3883752fd2889a323bfd97698c58706",
+    "uri": "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook@sha256:737704b79369f336c8c05b4b28fd2da0e3883752fd2889a323bfd97698c58706",
+    "tags": ["exp_w_2077_42_c0049.001_testing"],
+    "image_size_bytes": 123456,
+    "upload_time": "2023-03-27T13:02:39Z",
+    "media_type": "application/vnd.docker.distribution.manifest.v2+json",
+    "build_time": "2023-03-27T13:02:39Z",
+    "update_time": "2023-03-27T13:02:39Z"
+  }
+]

--- a/tests/configs/gar-cycle/input/nodes.json
+++ b/tests/configs/gar-cycle/input/nodes.json
@@ -1,0 +1,22 @@
+{
+  "node1": [
+    {
+      "names": [
+        "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook@sha256:49d63632237c3c0ca10c2c8de1e4310acadea2cdf2f9eaed0e2d2c0c27736c0b"
+      ],
+      "sizeBytes": 123456
+    },
+    {
+      "names": [
+        "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook@sha256:b14b81ae38caa6c6d919fc02c202b5d2a99dcce0d4c16ee6ad08b3831e814403"
+      ],
+      "sizeBytes": 23524
+    },
+    {
+      "names": [
+        "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook@sha256:9401f5d181180167d2a2b1d111456a4b9b506245bc43da8c4c869a87d512ecda"
+      ],
+      "sizeBytes": 124513
+    }
+  ]
+}

--- a/tests/configs/gar-cycle/output/images.json
+++ b/tests/configs/gar-cycle/output/images.json
@@ -1,0 +1,88 @@
+{
+  "recommended": {
+    "reference": "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook:recommended_c0050",
+    "tag": "recommended_c0050",
+    "name": "Recommended (Weekly 2077_43, SAL Cycle 0050, Build 002)",
+    "digest": "sha256:49d63632237c3c0ca10c2c8de1e4310acadea2cdf2f9eaed0e2d2c0c27736c0b",
+    "aliases": [
+      "w_2077_43_c0050.002"
+    ],
+    "prepulled": true
+  },
+  "latest_weekly": {
+    "reference": "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook:w_2077_43_c0050.004",
+    "tag": "w_2077_43_c0050.004",
+    "name": "Weekly 2077_43 (SAL Cycle 0050, Build 004)",
+    "digest": "sha256:b14b81ae38caa6c6d919fc02c202b5d2a99dcce0d4c16ee6ad08b3831e814403",
+    "aliases": [
+      "latest_c0050"
+    ],
+    "prepulled": true
+  },
+  "all": [
+    {
+      "reference": "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook:recommended_c0050",
+      "tag": "recommended_c0050",
+      "name": "Recommended (Weekly 2077_43, SAL Cycle 0050, Build 002)",
+      "digest": "sha256:49d63632237c3c0ca10c2c8de1e4310acadea2cdf2f9eaed0e2d2c0c27736c0b",
+      "aliases": [
+        "w_2077_43_c0050.002"
+      ],
+      "prepulled": true
+    },
+    {
+      "reference": "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook:latest_c0050",
+      "tag": "latest_c0050",
+      "name": "Latest (Weekly 2077_43, SAL Cycle 0050, Build 004)",
+      "digest": "sha256:b14b81ae38caa6c6d919fc02c202b5d2a99dcce0d4c16ee6ad08b3831e814403",
+      "aliases": [
+        "w_2077_43_c0050.004"
+      ],
+      "prepulled": true
+    },
+    {
+      "reference": "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook:w_2077_43_c0050.004",
+      "tag": "w_2077_43_c0050.004",
+      "name": "Weekly 2077_43 (SAL Cycle 0050, Build 004)",
+      "digest": "sha256:b14b81ae38caa6c6d919fc02c202b5d2a99dcce0d4c16ee6ad08b3831e814403",
+      "aliases": [
+        "latest_c0050"
+      ],
+      "prepulled": true
+    },
+    {
+      "reference": "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook:w_2077_43_c0050.003",
+      "tag": "w_2077_43_c0050.003",
+      "name": "Weekly 2077_43 (SAL Cycle 0050, Build 003)",
+      "digest": "sha256:9401f5d181180167d2a2b1d111456a4b9b506245bc43da8c4c869a87d512ecda",
+      "aliases": [],
+      "prepulled": true
+    },
+    {
+      "reference": "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook:w_2077_43_c0050.002",
+      "tag": "w_2077_43_c0050.002",
+      "name": "Weekly 2077_43 (SAL Cycle 0050, Build 002)",
+      "digest": "sha256:49d63632237c3c0ca10c2c8de1e4310acadea2cdf2f9eaed0e2d2c0c27736c0b",
+      "aliases": [
+        "recommended_c0050"
+      ],
+      "prepulled": true
+    },
+    {
+      "reference": "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook:w_2077_43_c0050.001",
+      "tag": "w_2077_43_c0050.001",
+      "name": "Weekly 2077_43 (SAL Cycle 0050, Build 001)",
+      "digest": "sha256:7d890dd00b7677de625d579e7927ff05e0fb009ef54fe66850288b845d33c1f6",
+      "aliases": [],
+      "prepulled": false
+    },
+    {
+      "reference": "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook:exp_w_2077_41_c0050.002_testing",
+      "tag": "exp_w_2077_41_c0050.002_testing",
+      "name": "Experimental Weekly 2077_41 (SAL Cycle 0050, Build 002) [testing]",
+      "digest": "sha256:9c57a60107e99e7a6cfcf395c26ff3bdabd3a92e88dabe3b5f1974326c7e991a",
+      "aliases": [],
+      "prepulled": false
+    }
+  ]
+}

--- a/tests/configs/gar-cycle/output/menu.json
+++ b/tests/configs/gar-cycle/output/menu.json
@@ -1,0 +1,46 @@
+{
+  "menu": [
+    {
+      "reference": "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook:recommended_c0050@sha256:49d63632237c3c0ca10c2c8de1e4310acadea2cdf2f9eaed0e2d2c0c27736c0b",
+      "name": "Recommended (Weekly 2077_43, SAL Cycle 0050, Build 002)"
+    },
+    {
+      "reference": "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook:w_2077_43_c0050.004@sha256:b14b81ae38caa6c6d919fc02c202b5d2a99dcce0d4c16ee6ad08b3831e814403",
+      "name": "Weekly 2077_43 (SAL Cycle 0050, Build 004)"
+    },
+    {
+      "reference": "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook:w_2077_43_c0050.003@sha256:9401f5d181180167d2a2b1d111456a4b9b506245bc43da8c4c869a87d512ecda",
+      "name": "Weekly 2077_43 (SAL Cycle 0050, Build 003)"
+    }
+  ],
+  "dropdown": [
+    {
+      "reference": "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook:recommended_c0050@sha256:49d63632237c3c0ca10c2c8de1e4310acadea2cdf2f9eaed0e2d2c0c27736c0b",
+      "name": "Recommended (Weekly 2077_43, SAL Cycle 0050, Build 002)"
+    },
+    {
+      "reference": "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook:latest_c0050@sha256:b14b81ae38caa6c6d919fc02c202b5d2a99dcce0d4c16ee6ad08b3831e814403",
+      "name": "Latest (Weekly 2077_43, SAL Cycle 0050, Build 004)"
+    },
+    {
+      "reference": "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook:w_2077_43_c0050.004@sha256:b14b81ae38caa6c6d919fc02c202b5d2a99dcce0d4c16ee6ad08b3831e814403",
+      "name": "Weekly 2077_43 (SAL Cycle 0050, Build 004)"
+    },
+    {
+      "reference": "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook:w_2077_43_c0050.003@sha256:9401f5d181180167d2a2b1d111456a4b9b506245bc43da8c4c869a87d512ecda",
+      "name": "Weekly 2077_43 (SAL Cycle 0050, Build 003)"
+    },
+    {
+      "reference": "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook:w_2077_43_c0050.002@sha256:49d63632237c3c0ca10c2c8de1e4310acadea2cdf2f9eaed0e2d2c0c27736c0b",
+      "name": "Weekly 2077_43 (SAL Cycle 0050, Build 002)"
+    },
+    {
+      "reference": "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook:w_2077_43_c0050.001@sha256:7d890dd00b7677de625d579e7927ff05e0fb009ef54fe66850288b845d33c1f6",
+      "name": "Weekly 2077_43 (SAL Cycle 0050, Build 001)"
+    },
+    {
+      "reference": "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook:exp_w_2077_41_c0050.002_testing@sha256:9c57a60107e99e7a6cfcf395c26ff3bdabd3a92e88dabe3b5f1974326c7e991a",
+      "name": "Experimental Weekly 2077_41 (SAL Cycle 0050, Build 002) [testing]"
+    }
+  ]
+}


### PR DESCRIPTION
Cycle filtering wasn't implemented on RSPImageCollection or plumbed through to the Google Artifact Registry storage layer. Do that, and add a test suite for cycle handling with Google Artifact Registry as well.

This uncovered a few more capitalization problems when an unknown tag with a cycle is later resolved into an alias. Fix those by always title-casing the display name when resolving the alias.