### PR TITLE
DM-38554: Set EXTERNAL_{UID,GID} for init containers

### DIFF
--- a/tests/configs/standard/output/lab-objects.json
+++ b/tests/configs/standard/output/lab-objects.json
@@ -285,6 +285,16 @@
       ],
       "init_containers": [
         {
+          "env": [
+            {
+              "name": "EXTERNAL_GID",
+              "value": "1101"
+            },
+            {
+              "name": "EXTERNAL_UID",
+              "value": "1101"
+            }
+          ],
           "env_from": [
             {
               "config_map_ref": {


### PR DESCRIPTION
Our init container implementation depended on these variables, even though the main lab no longer does. Set them directly for init containers.