### PR TITLE
DM-38795: Construct a new K8sStorageClient for each request

### DIFF
--- a/src/jupyterlabcontroller/storage/k8s.py
+++ b/src/jupyterlabcontroller/storage/k8s.py
@@ -47,15 +47,12 @@ __all__ = ["K8sStorageClient"]
 
 class K8sStorageClient:
     def __init__(
-        self, k8s_api: ApiClient, timeout: int, logger: BoundLogger
+        self, kubernetes_client: ApiClient, timeout: int, logger: BoundLogger
     ) -> None:
-        self.k8s_api = k8s_api
-        self.api = client.CoreV1Api(k8s_api)
+        self.k8s_api = kubernetes_client
+        self.api = client.CoreV1Api(kubernetes_client)
         self.timeout = timeout
         self._logger = logger
-
-    async def aclose(self) -> None:
-        await self.k8s_api.close()
 
     async def create_user_namespace(self, name: str) -> None:
         """Create the namespace for a user's lab.


### PR DESCRIPTION
Rather than maintaining a global K8sStorageClient, just keep a global kubernetes_asyncio client (to maintain the connection pool) and create new K8sStorageClient objects with each request. This will improve the logging by attaching the per-request logger to the K8sStorageClient when spawning labs, so those log messages will get more context.