### PR TITLE
DM-38795: Overhaul task tracking for lab spawns

### DIFF
--- a/src/jupyterlabcontroller/handlers/labs.py
+++ b/src/jupyterlabcontroller/handlers/labs.py
@@ -41,7 +41,7 @@ async def get_lab_users(
     },
     summary="Status of user's lab",
 )
-async def get_state(
+async def get_lab_state(
     username: str,
     context: RequestContext = Depends(context_dependency),
 ) -> UserLabState:
@@ -83,7 +83,7 @@ async def post_new_lab(
         e.location = ErrorLocation.body
         e.field_path = ["options", lab.options.image_attribute]
         raise
-    url = context.request.url_for("get_state", username=username)
+    url = context.request.url_for("get_lab_state", username=username)
     response.headers["Location"] = str(url)
 
 

--- a/src/jupyterlabcontroller/handlers/user_status.py
+++ b/src/jupyterlabcontroller/handlers/user_status.py
@@ -16,7 +16,7 @@ __all__ = ["router"]
 @router.get(
     "/spawner/v1/user-status",
     responses={404: {"description": "Lab not found", "model": ErrorModel}},
-    summary="Status of user's lab",
+    summary="State of user's lab",
     response_model=UserLabState,
 )
 async def get_user_state(

--- a/src/jupyterlabcontroller/models/domain/lab.py
+++ b/src/jupyterlabcontroller/models/domain/lab.py
@@ -1,9 +1,45 @@
-from dataclasses import dataclass
+"""Internal models related to user labs."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Optional
 
 from kubernetes_asyncio.client.models import V1Volume, V1VolumeMount
+
+from ..v1.event import Event
+from ..v1.lab import UserLabState
+
+__all__ = [
+    "LabVolumeContainer",
+    "UserLab",
+]
 
 
 @dataclass
 class LabVolumeContainer:
     volume: V1Volume
     volume_mount: V1VolumeMount
+
+
+@dataclass
+class UserLab:
+    """Collects all internal state for a user's lab."""
+
+    state: UserLabState
+    """Current state of the lab, in the form returned by status routes."""
+
+    events: list[Event] = field(default_factory=list)
+    """Events from the current or most recent lab operation."""
+
+    triggers: list[asyncio.Event] = field(default_factory=list)
+    """Triggers used to notify event stream listeners of new events."""
+
+    spawner: Optional[asyncio.Task[None]] = None
+    """Background task monitoring the progress of a lab operation.
+
+    These tasks are not wrapped in an `aiojobs.Spawner` because the
+    `aiojobs.Job` abstraction doesn't have a done method, which we use to poll
+    each running spawner to see which ones have finished.
+    """

--- a/src/jupyterlabcontroller/models/v1/lab.py
+++ b/src/jupyterlabcontroller/models/v1/lab.py
@@ -1,6 +1,5 @@
 """Models for jupyterlab-controller."""
 
-from collections import deque
 from enum import Enum
 from typing import Any, Optional, Self
 
@@ -13,7 +12,22 @@ from ...constants import (
     USERNAME_REGEX,
 )
 from ...util import str_to_bool
-from .event import Event
+
+__all__ = [
+    "ImageClass",
+    "LabSize",
+    "LabSpecification",
+    "LabStatus",
+    "NotebookQuota",
+    "PodState",
+    "UserGroup",
+    "UserInfo",
+    "UserLabState",
+    "UserOptions",
+    "UserQuota",
+    "UserResourceQuantum",
+    "UserResources",
+]
 
 
 class LabSize(str, Enum):
@@ -325,6 +339,8 @@ class UserResources(BaseModel):
 
 
 class UserLabState(UserInfo, LabSpecification):
+    """Current state of the user's lab."""
+
     status: LabStatus = Field(
         ...,
         example="running",
@@ -346,10 +362,6 @@ class UserLabState(UserInfo, LabSpecification):
         title="URL by which the Hub can access the user Pod",
     )
     resources: UserResources = Field(..., title="Resource requests and limits")
-    events: deque[Event] = Field(
-        default_factory=deque,
-        title="Ordered queue of events for user lab creation/deletion",
-    )
 
     @classmethod
     def new_from_user_resources(
@@ -361,7 +373,6 @@ class UserLabState(UserInfo, LabSpecification):
         return cls(
             options=labspec.options,
             env=labspec.env,
-            events=deque(),
             status=LabStatus.PENDING,
             pod=PodState.MISSING,
             resources=resources,

--- a/src/jupyterlabcontroller/services/lab.py
+++ b/src/jupyterlabcontroller/services/lab.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 from asyncio import Task, create_task
 from copy import copy, deepcopy
+from functools import partial
 from pathlib import Path
 from typing import Optional
 
@@ -88,26 +89,6 @@ class LabManager:
         """Exposed because the unit tests use it."""
         return f"{self.manager_namespace}-{username}"
 
-    async def await_pod_spawn(self, namespace: str, username: str) -> None:
-        """This is designed to run as a background task and just wait until
-        the pod has been created and inject a completion event into the
-        event queue when it has.
-        """
-        try:
-            await self.k8s_client.wait_for_pod_creation(
-                podname=f"nb-{username}", namespace=namespace
-            )
-        except Exception as e:
-            self._logger.exception("Pod creation failed")
-            await self._lab_state.publish_error(username, str(e), fatal=True)
-        else:
-            await self._lab_state.publish_completion(
-                username,
-                f"Lab Kubernetes pod started for {username}",
-                f"http://lab.{namespace}:8888",
-            )
-            self._logger.info("Lab created")
-
     async def await_ns_deletion(self, namespace: str, username: str) -> None:
         """This is designed to run as a background task and just wait until
         the pod has been created and inject a completion event into the
@@ -179,27 +160,21 @@ class LabManager:
             tag = lab.options.image_tag
             image = await self._image_service.image_for_tag_name(tag)
 
-        # Set up the lab state and send the initial lab creation event. This
-        # also checks for conflicts and raises an exception if the lab already
-        # exists.
-        #
-        # FIXME: Handle labs in failed state, which should be removed before
-        # starting to create a new lab.
+        # Construct the initial lab state from the route input.
         state = UserLabState.new_from_user_resources(
             user=user,
             labspec=lab,
             resources=self._size_manager.resources(lab.options.size),
         )
-        self._logger.info("Creating new lab")
-        msg = f"Starting lab creation for {user.username}"
-        await self._lab_state.publish_start_creation(user.username, msg, state)
 
-        # This is all that we should do synchronously in response to the API
-        # call. The rest should be done in the background, reporting status
-        # through the event stream. Kick off the background job.
-        pod_spawn_task = create_task(self._spawn_lab(user, token, lab, image))
-        self._tasks.add(pod_spawn_task)
-        pod_spawn_task.add_done_callback(self._tasks.discard)
+        # Start the spawning process. This also checks for conflicts and
+        # raises an exception if the lab already exists.
+        #
+        # FIXME: Handle labs in failed state, which should be removed before
+        # starting to create a new lab.
+        self._logger.info("Creating new lab")
+        spawner = partial(self._spawn_lab, user, token, lab, image)
+        await self._lab_state.start_spawn(user.username, state, spawner)
 
     async def _spawn_lab(
         self,
@@ -207,46 +182,70 @@ class LabManager:
         token: str,
         lab: LabSpecification,
         image: RSPImage,
-    ) -> None:
+    ) -> str:
+        """Do the work of creating a user's lab.
+
+        This method is responsible for creating the Kubernetes objects and
+        telling Kubernetes to start the user's pod. It does not wait for the
+        pod to finish starting. It is run within a background task managed by
+        `~jupyterlabcontroller.services.state.LabStateManager`, which then
+        waits for the lab to start and updates internal state as appropriate.
+
+        Parameters
+        ----------
+        user
+            Identity information for the user spawning the lab.
+        token
+            Gafaelfawr notebook token for the user.
+        lab
+            Specification for the lab environment to create.
+        image
+            Docker image to run as the lab.
+
+        Returns
+        -------
+        str
+            Cluster-internal URL at which the lab will be listening once it
+            has finished starting.
+        """
         username = user.username
         namespace = self.namespace_from_user(username)
 
         # This process has three stages. First, create or recreate the user's
-        # namespace. Second, create all the supporting resources the lab pod
-        # will need. Finally, create the lab pod and wait for it to start,
-        # reflecting any events back to the events API.
-        try:
-            await self.k8s_client.create_user_namespace(namespace)
-            await self._lab_state.publish_event(
-                username, "Created user namespace", 5
-            )
-            await self.create_user_lab_objects(
-                user=user, lab=lab, image=image, token=token
-            )
-            await self._lab_state.publish_event(
-                username, "Created Kubernetes resources for lab", 25
-            )
-            resources = self._size_manager.resources(lab.options.size)
-            await self.create_user_pod(user, resources, image)
-            await self._lab_state.publish_pod_creation(
-                username, "Requested lab Kubernetes pod", 30
-            )
-        except Exception as e:
-            self._logger.exception("Lab creation failed")
-            if self._slack_client:
-                if isinstance(e, SlackException):
-                    e.user = username
-                    await self._slack_client.post_exception(e)
-                else:
-                    await self._slack_client.post_uncaught_exception(e)
-            await self._lab_state.publish_error(username, str(e), fatal=True)
-            return
+        # namespace.
+        await self.k8s_client.create_user_namespace(namespace)
+        await self._lab_state.publish_event(
+            username, "Created user namespace", 5
+        )
+
+        # Second, create all the supporting resources the lab pod will need.
+        await self.create_secrets(
+            username=username,
+            namespace=self.namespace_from_user(username),
+            token=token,
+        )
+        await self.create_nss(user)
+        await self.create_file_configmap(user)
+        await self.create_env(user=user, lab=lab, image=image, token=token)
+        await self.create_network_policy(user)
+        await self.create_quota(user)
+        await self.create_lab_service(user)
+        await self._lab_state.publish_event(
+            username, "Created Kubernetes resources for lab", 25
+        )
+
+        # Finally, create the lab pod.
+        resources = self._size_manager.resources(lab.options.size)
+        await self.create_user_pod(user, resources, image)
+        await self._lab_state.publish_pod_creation(
+            username, "Requested lab Kubernetes pod", 30
+        )
 
         # Create a task to monitor and inject pod events during spawn.
         evt_task = create_task(
             self.inject_pod_events(
                 namespace=namespace,
-                username=user.username,
+                username=username,
                 start_progress=35,
                 end_progress=75,
             )
@@ -254,37 +253,8 @@ class LabManager:
         self._tasks.add(evt_task)
         evt_task.add_done_callback(self._tasks.discard)
 
-        # Now, wait for the pod to spawn.
-        await self.await_pod_spawn(namespace=namespace, username=user.username)
-
-    async def create_user_lab_objects(
-        self,
-        *,
-        user: UserInfo,
-        lab: LabSpecification,
-        image: RSPImage,
-        token: str,
-    ) -> None:
-        username = user.username
-
-        # Doing this in parallel causes a crash, and it's very hard to
-        # debug with aiojobs because we do not have the actual failures
-        # from the control plane.
-
-        # Doing it sequentially doesn't actually wait for resource creation,
-        # because it's an async K8s call, and each call completes quickly.
-
-        await self.create_secrets(
-            username=username,
-            namespace=self.namespace_from_user(username),
-            token=token,
-        )
-        await self.create_nss(user=user)
-        await self.create_file_configmap(user=user)
-        await self.create_env(user=user, lab=lab, image=image, token=token)
-        await self.create_network_policy(user=user)
-        await self.create_quota(user)
-        await self.create_lab_service(user=user)
+        # Return the URL where the lab will be listening after it starts.
+        return f"http://lab.{namespace}:8888"
 
     async def create_secrets(
         self, username: str, token: str, namespace: str

--- a/src/jupyterlabcontroller/services/lab.py
+++ b/src/jupyterlabcontroller/services/lab.py
@@ -843,7 +843,6 @@ class LabManager:
         return pod
 
     async def delete_lab(self, username: str) -> None:
-        await self._lab_state.reset_user_events(username)
         await self._lab_state.publish_start_deletion(
             username, "Deleting user lab and resources", 25
         )

--- a/src/jupyterlabcontroller/services/state.py
+++ b/src/jupyterlabcontroller/services/state.py
@@ -15,6 +15,7 @@ from structlog.stdlib import BoundLogger
 
 from ..constants import LAB_STATE_REFRESH_INTERVAL
 from ..exceptions import LabExistsError, UnknownUserError
+from ..models.domain.lab import UserLab
 from ..models.v1.event import Event, EventType
 from ..models.v1.lab import LabStatus, PodState, UserLabState
 from ..storage.k8s import K8sStorageClient
@@ -60,29 +61,14 @@ class LabStateManager:
         # Background task management.
         self._scheduler: Optional[Scheduler] = None
 
-        # Mapping of usernames to last known lab state.
-        self._labs: dict[str, UserLabState] = {}
-
-        # Mapping of usernames to spawn events for that user.
-        self._events: dict[str, list[Event]] = {}
-
-        # Triggers per user that we use to notify any listeners of new events.
-        self._triggers: dict[str, list[asyncio.Event]] = {}
-
-        # Users whose labs are currently being spawned. The values are the
-        # running background tasks monitoring the spawn progress. These are
-        # excluded from periodic state reconciliation so that we don't race
-        # with ourselves and incorrectly update user lab state.
-        #
-        # These tasks are not wrapped in an aiojobs.Spawner because the
-        # aiojobs.Job abstraction doesn't have a done method, and therefore
-        # these spawner threads must be manually shut down when background
-        # threads are stopped.
-        self._in_progress: dict[str, asyncio.Task[None]] = {}
+        # Mapping of usernames to internal lab state.
+        self._labs: dict[str, UserLab] = {}
 
         # Triggered when any background thread monitoring spawn progress
         # completes. This has to be triggered manually, so there must be a
-        # top-level exception handler that ensures it is set.
+        # top-level exception handler for each spawner task that ensures it is
+        # set when the spawner task exits for any reason. Otherwise, the
+        # reaper task may never realize a spawner has finished and wake up.
         self._spawner_done = asyncio.Event()
 
     def events_for_user(self, username: str) -> AsyncIterator[ServerSentEvent]:
@@ -106,15 +92,23 @@ class LabStateManager:
         UnknownUserError
             Raised if there is no event stream for this user.
         """
-        if username not in self._events:
+        if username not in self._labs:
             raise UnknownUserError(f"Unknown user {username}")
 
-        events = self._events[username]
+        # Get the event list and add our trigger to it. We grab a separate
+        # reference to the event list, rather than using self._labs inside the
+        # iterator, so that if the event list is cleared (via replacement with
+        # an empty list) while we are listening, we will only see the old
+        # list.
+        events = self._labs[username].events
         trigger = asyncio.Event()
         if events:
             trigger.set()
-        self._triggers[username].append(trigger)
+        self._labs[username].triggers.append(trigger)
 
+        # The iterator waits for the trigger and returns any new events,
+        # calling _remove_trigger after it sees an event that indicates the
+        # operation has completed.
         async def iterator() -> AsyncIterator[ServerSentEvent]:
             position = 0
             try:
@@ -138,7 +132,7 @@ class LabStateManager:
         Parameters
         ----------
         username
-            Username to retrieve state for.
+            Username to retrieve lab state for.
 
         Returns
         -------
@@ -148,10 +142,10 @@ class LabStateManager:
         Raises
         ------
         UnknownUserError
-            Raised if the given user has no lab state.
+            Raised if the given user has no lab.
         """
         if username in self._labs:
-            return self._labs[username]
+            return self._labs[username].state
         else:
             raise UnknownUserError(f"Unknown user {username}")
 
@@ -173,13 +167,16 @@ class LabStateManager:
             return [
                 u
                 for u, s in self._labs.items()
-                if s.status == LabStatus.RUNNING
+                if s.state.status == LabStatus.RUNNING
             ]
         else:
             return list(self._labs.keys())
 
     async def publish_deletion(self, username: str, message: str) -> None:
         """Publish a lab deletion completion event for a user.
+
+        Notifies any current listeners to the event stream that the operation
+        is complete before deleting the recorded user state entirely.
 
         Parameters
         ----------
@@ -190,7 +187,9 @@ class LabStateManager:
         """
         event = Event(message=message, type=EventType.COMPLETE)
         await self._add_event(username, event)
+        lab = self._labs[username]
         del self._labs[username]
+        await self._clear_events(lab)
 
     async def publish_error(
         self, username: str, message: str, fatal: bool = False
@@ -212,9 +211,9 @@ class LabStateManager:
         if fatal:
             event = Event(message="Lab creation failed", type=EventType.FAILED)
             await self._add_event(username, event)
-            self._logger.error("Lab creation failed")
-            self._labs[username].status = LabStatus.FAILED
-            self._labs[username].internal_url = None
+            self._logger.error("Lab creation failed", user=username)
+            self._labs[username].state.status = LabStatus.FAILED
+            self._labs[username].state.internal_url = None
 
     async def publish_event(
         self, username: str, message: str, progress: int
@@ -233,7 +232,7 @@ class LabStateManager:
         event = Event(message=message, progress=progress, type=EventType.INFO)
         await self._add_event(username, event)
         msg = f"Spawning event: {message}"
-        self._logger.debug(msg, username=username, progress=progress)
+        self._logger.debug(msg, user=username, progress=progress)
 
     async def publish_pod_creation(
         self, username: str, message: str, progress: int
@@ -252,8 +251,8 @@ class LabStateManager:
             New progress percentage.
         """
         await self.publish_event(username, message, progress)
-        self._labs[username].pod = PodState.PRESENT
-        self._labs[username].status = LabStatus.PENDING
+        self._labs[username].state.pod = PodState.PRESENT
+        self._labs[username].state.status = LabStatus.PENDING
 
     async def publish_start_deletion(
         self, username: str, message: str, progress: int
@@ -278,37 +277,11 @@ class LabStateManager:
         """
         if username not in self._labs:
             raise UnknownUserError(f"Unknown user {username}")
-        self._labs[username].status = LabStatus.TERMINATING
-        self._labs[username].internal_url = None
+        lab = self._labs[username]
+        await self._clear_events(lab)
+        lab.state.status = LabStatus.TERMINATING
+        lab.state.internal_url = None
         await self.publish_event(username, message, progress)
-
-    async def reset_user_events(self, username: str) -> None:
-        """Reset the event queue for a user.
-
-        Called when we delete the user's lab or otherwise reset the user's
-        state such that old events are no longer of interest.
-
-        Parameters
-        ----------
-        username
-            Username to reset.
-        """
-        if username not in self._events:
-            return
-
-        # Detach the list of events from our data so that no more can be
-        # added. If the final event in the list of events is not a completion
-        # event, add a synthetic completion event. Then notify any listeners.
-        # This ensures all the listeners will complete.
-        events = self._events[username]
-        del self._events[username]
-        if not events or not events[-1].done:
-            event = Event(message="Operation aborted", type=EventType.FAILED)
-            events.append(event)
-        triggers = self._triggers[username]
-        del self._triggers[username]
-        for trigger in triggers:
-            trigger.set()
 
     async def start(self) -> None:
         """Synchronize with Kubernetes and start a background refresh task.
@@ -357,9 +330,9 @@ class LabStateManager:
             msg = "Lab already exists"
             await self.publish_error(username, msg, fatal=True)
             raise LabExistsError(f"Lab already exists for {username}")
-        self._labs[username] = state
+        self._labs[username] = UserLab(state=state)
         task = asyncio.create_task(self._spawn(username, spawner))
-        self._in_progress[username] = task
+        self._labs[username].spawner = task
 
     async def stop(self) -> None:
         """Stop the background refresh task."""
@@ -371,13 +344,15 @@ class LabStateManager:
         await self._scheduler.close()
         self._scheduler = None
         self._logger.info("Stopping spawning monitor tasks")
-        for spawner in self._in_progress.values():
-            spawner.cancel("Shutting down")
-            try:
-                await spawner
-            except asyncio.CancelledError:
-                pass
-        self._in_progress = {}
+        for state in self._labs.values():
+            if state.spawner:
+                spawner = state.spawner
+                state.spawner = None
+                spawner.cancel("Shutting down")
+                try:
+                    await spawner
+                except asyncio.CancelledError:
+                    pass
 
     async def _add_event(self, username: str, event: Event) -> None:
         """Publish an event for the given user.
@@ -389,13 +364,36 @@ class LabStateManager:
         event
             Event to publish.
         """
-        if username in self._events:
-            self._events[username].append(event)
-            for trigger in self._triggers[username]:
-                trigger.set()
-        else:
-            self._events[username] = [event]
-            self._triggers[username] = []
+        self._labs[username].events.append(event)
+        for trigger in self._labs[username].triggers:
+            trigger.set()
+
+    async def _clear_events(self, lab: UserLab) -> None:
+        """Safely clear the event list for a user.
+
+        If the record for the user is about to be deleted, remove it from
+        ``self._labs`` before calling this method to ensure that nothing
+        starts adding new events and triggers while the deletion is in
+        progress.
+
+        Parameters
+        ----------
+        lab
+            User lab data holding the event stream to clear.
+        """
+        events = lab.events
+        triggers = lab.triggers
+        lab.events = []
+        lab.triggers = []
+
+        # If the final event in the list of events is not a completion
+        # event, add a synthetic completion event. Then notify any listeners.
+        # This ensures all the listeners will complete.
+        if not events or not events[-1].done:
+            event = Event(message="Operation aborted", type=EventType.FAILED)
+            events.append(event)
+        for trigger in triggers:
+            trigger.set()
 
     async def _reap_spawners(self) -> None:
         """Wait for spawner tasks to complete and record their status.
@@ -417,9 +415,10 @@ class LabStateManager:
         while True:
             await self._spawner_done.wait()
             self._spawner_done.clear()
-            finished = []
-            for username, spawner in self._in_progress.items():
-                if spawner.done():
+            for username, state in self._labs.items():
+                if state.spawner and state.spawner.done():
+                    spawner = state.spawner
+                    state.spawner = None
                     try:
                         await spawner
                     except Exception as e:
@@ -427,13 +426,7 @@ class LabStateManager:
                         self._logger.exception(msg, user=username)
                         if self._slack:
                             await self._slack.post_uncaught_exception(e)
-                        if username in self._labs:
-                            self._labs[username].status = LabStatus.FAILED
-                    finally:
-                        finished.append(username)
-            for username in finished:
-                if username in self._in_progress:
-                    del self._in_progress[username]
+                        state.state.status = LabStatus.FAILED
 
     async def _reconcile_lab_state(self) -> None:
         """Reconcile user lab state with Kubernetes.
@@ -444,43 +437,49 @@ class LabStateManager:
         recreate the internal state from the contents of Kubernetes.
         """
         self._logger.info("Reconciling user lab state with Kubernetes")
+        known_users = set(self._labs.keys())
         observed = await self._kubernetes.get_observed_user_state(
             self._namespace_prefix
         )
-        known_users = set(self._labs.keys())
+
+        # If the set of users we expected to see changed during
+        # reconciliation, we may be running into all sorts of race
+        # conditions. Just skip this background update; we'll catch any
+        # inconsistencies the next time around.
+        if set(self._labs.keys()) != known_users:
+            msg = "Known users changed during reconciliation, skipping"
+            self._logger.info(msg)
+            return
 
         # First pass: check all users already recorded in internal state
         # against Kubernetes and correct them (or remove them) if needed.
-        for username in known_users:
-            if username in self._in_progress:
+        for username, lab in list(self._labs.items()):
+            if lab.spawner is not None:
                 continue
-            state = self._labs[username]
-            if state.status == LabStatus.FAILED:
+            if lab.state.status == LabStatus.FAILED:
                 continue
             if username not in observed:
                 msg = f"Expected user {username} not found in Kubernetes"
                 self._logger.warning(msg)
-                await self.reset_user_events(username)
-                del self._labs[username]
+                await self.publish_deletion(username, "Lab pod disappeared")
             else:
                 observed_state = observed[username]
-                if observed_state.status != state.status:
+                if observed_state.status != lab.state.status:
                     self._logger.warning(
-                        f"Expected status for {username} is {state.status},"
-                        f" but observed status is {observed_state.status}"
+                        f"Expected status for {username} is"
+                        f" {lab.state.status}, but observed status is"
+                        f" {observed_state.status}"
                     )
-                    state.status = observed_state.status
+                    lab.state.status = observed_state.status
 
         # Second pass: take observed state and create any missing internal
         # state. This is the normal case after a restart of the lab
         # controller.
-        for username in observed.keys():
-            if username in self._in_progress:
-                continue
+        for username in set(observed.keys()) - known_users:
             if username not in self._labs:
                 msg = f"Creating record for user {username} from Kubernetes"
                 self._logger.info(msg)
-                self._labs[username] = observed[username]
+                self._labs[username] = UserLab(state=observed[username])
 
     async def _refresh_loop(self) -> None:
         """Run in the background by `start`, stopped with `stop`."""
@@ -515,10 +514,10 @@ class LabStateManager:
         trigger
             Corresponding trigger to remove.
         """
-        if username not in self._triggers:
+        if username not in self._labs:
             return
-        self._triggers[username] = [
-            t for t in self._triggers[username] if t != trigger
+        self._labs[username].triggers = [
+            t for t in self._labs[username].triggers if t != trigger
         ]
 
     async def _spawn(
@@ -541,7 +540,7 @@ class LabStateManager:
         namespace = f"{self._namespace_prefix}-{username}"
         pod_name = f"nb-{username}"
         try:
-            await self.reset_user_events(username)
+            await self._clear_events(self._labs[username])
             msg = f"Starting lab creation for {username}"
             await self.publish_event(username, msg, 1)
             internal_url = await spawner()
@@ -559,8 +558,8 @@ class LabStateManager:
             msg = f"Lab Kubernetes pod started for {username}"
             event = Event(message=msg, type=EventType.COMPLETE)
             await self._add_event(username, event)
-            self._labs[username].status = LabStatus.RUNNING
-            self._labs[username].internal_url = internal_url
+            self._labs[username].state.status = LabStatus.RUNNING
+            self._labs[username].state.internal_url = internal_url
             self._logger.info("Lab created")
         finally:
             self._spawner_done.set()

--- a/tests/configs/standard/output/pod-events.json
+++ b/tests/configs/standard/output/pod-events.json
@@ -1,6 +1,6 @@
 [
   {
-    "data": "{\"message\": \"Starting lab creation for rachel\", \"progress\": 2}",
+    "data": "{\"message\": \"Starting lab creation for rachel\", \"progress\": 1}",
     "event": "info"
   },
   {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,6 +56,7 @@ async def app(
     mock_docker: MockDockerRegistry,
     mock_kubernetes: MockKubernetesApi,
     mock_gafaelfawr: MockGafaelfawr,
+    mock_slack: MockSlackWebhook,
     obj_factory: TestObjectFactory,
 ) -> AsyncIterator[FastAPI]:
     """Return a configured test application.

--- a/tests/handlers/labs_test.py
+++ b/tests/handlers/labs_test.py
@@ -136,7 +136,6 @@ async def test_lab_start_stop(
     expected_options["image_list"] = None
     assert r.json() == {
         "env": lab.env,
-        "events": [],
         "gid": user.gid,
         "groups": user.dict()["groups"],
         "internal_url": f"http://lab.userlabs-{user.username}:8888",
@@ -179,14 +178,6 @@ async def test_lab_start_stop(
     assert r.json() == []
     r = await client.get(f"/nublado/spawner/v1/labs/{user.username}")
     assert r.status_code == 404
-
-    # Events should be for lab deletion and should return immediately.
-    r = await client.get(
-        f"/nublado/spawner/v1/labs/{user.username}/events",
-        headers={"X-Auth-Request-User": user.username},
-    )
-    assert r.status_code == 200
-    assert "Deleting user lab and resources" in r.text
 
 
 @pytest.mark.asyncio

--- a/tests/handlers/user_status_test.py
+++ b/tests/handlers/user_status_test.py
@@ -60,7 +60,6 @@ async def test_user_status(
     expected_resources = size_manager.resources(lab.options.size)
     assert r.json() == {
         "env": lab.env,
-        "events": [],
         "gid": user.gid,
         "groups": user.dict()["groups"],
         "internal_url": "http://lab.userlabs-rachel:8888",


### PR DESCRIPTION
Previously, when someone requested that a lab be spawned, this created a background task recorded in the `LabManager` that created the Kubernetes objects and then waited for the pod to finish starting. The drawback of this approach is that nothing ever reaped this background task to properly collect its return status or exception, resulting in Python errors about abandoned tasks.

Now that `LabManager` exists, hand over management of spawner tasks to it. Provide it with a callback that creates the Kubernetes objects, and move waiting for the lab to start into `LabStateManager`. These threads are now properly reaped by a long-running reaper background task. Move the exception handling and reporting for the spawner task into `LabStateManager` as well.

In addition to the benefit of better task tracking and management, this also lays the groundwork for spawning a monitoring task during startup if we detect a lab spawn in progress. It also allows making more of the event posting and state update machinery internal to `LabStateManager`, since it now knows when lab spawns complete and doesn't have to be told by other code.

Internally, collect all of the state information for a user's lab into a single data structure, which avoids accidental state inconsistencies. Use that data structure to skip reconciliation with Kubernetes when we know that actions are in progress on that lab, since otherwise we may race with ourselves. As a side effect, this means we no longer retain deletion events for a lab after the lab has been deleted, but on reflection I think this is correct REST semantics and we have no obvious use for those events.