### PR TITLE
DM-38795: Merge waiting for pod with event monitoring

### DIFF
--- a/src/jupyterlabcontroller/config.py
+++ b/src/jupyterlabcontroller/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from datetime import timedelta
 from enum import Enum
 from pathlib import Path
 from typing import Optional, Self
@@ -208,6 +209,9 @@ class LabFile(CamelCaseModel):
 
 
 class LabConfig(CamelCaseModel):
+    spawn_timeout: timedelta = Field(
+        timedelta(minutes=10), title="Timeout for lab spawning"
+    )
     sizes: dict[LabSize, LabSizeDefinition] = Field(
         {}, title="Lab sizes users may choose from"
     )

--- a/src/jupyterlabcontroller/factory.py
+++ b/src/jupyterlabcontroller/factory.py
@@ -87,6 +87,7 @@ class ProcessContext:
         k8s_client = K8sStorageClient(
             kubernetes_client=kubernetes_client,
             timeout=KUBERNETES_REQUEST_TIMEOUT,
+            spawn_timeout=config.lab.spawn_timeout,
             logger=logger,
         )
 
@@ -137,7 +138,7 @@ class ProcessContext:
                 logger=logger,
             ),
             lab_state=LabStateManager(
-                namespace_prefix=config.lab.namespace_prefix,
+                config=config.lab,
                 kubernetes=k8s_client,
                 slack_client=slack_client,
                 logger=logger,
@@ -288,6 +289,7 @@ class Factory:
         k8s_client = K8sStorageClient(
             kubernetes_client=self._context.kubernetes_client,
             timeout=KUBERNETES_REQUEST_TIMEOUT,
+            spawn_timeout=self._context.config.lab.spawn_timeout,
             logger=self._logger,
         )
         return LabManager(

--- a/src/jupyterlabcontroller/models/k8s.py
+++ b/src/jupyterlabcontroller/models/k8s.py
@@ -11,11 +11,3 @@ class Secret:
 class ObjectOperation(Enum):
     CREATION = "creation"
     DELETION = "deletion"
-
-
-class K8sPodPhase(str, Enum):
-    PENDING = "Pending"
-    RUNNING = "Running"
-    SUCCEEDED = "Succeeded"
-    FAILED = "Failed"
-    UNKNOWN = "Unknown"

--- a/tests/handlers/labs_test.py
+++ b/tests/handlers/labs_test.py
@@ -22,7 +22,7 @@ from safir.testing.slack import MockSlackWebhook
 from jupyterlabcontroller.config import Config
 from jupyterlabcontroller.constants import DROPDOWN_SENTINEL_VALUE
 from jupyterlabcontroller.factory import Factory
-from jupyterlabcontroller.models.k8s import K8sPodPhase
+from jupyterlabcontroller.models.domain.kubernetes import KubernetesPodPhase
 
 from ..settings import TestObjectFactory
 from ..support.constants import TEST_BASE_URL
@@ -190,7 +190,7 @@ async def test_delayed_spawn(
 ) -> None:
     token, user = obj_factory.get_user()
     lab = obj_factory.labspecs[0]
-    mock_kubernetes.initial_pod_status = K8sPodPhase.PENDING.value
+    mock_kubernetes.initial_pod_status = KubernetesPodPhase.PENDING.value
 
     r = await client.post(
         f"/nublado/spawner/v1/labs/{user.username}/create",
@@ -237,7 +237,7 @@ async def test_delayed_spawn(
 
     # Change the pod status to running and add another event.
     await asyncio.sleep(0.1)
-    pod.status.phase = K8sPodPhase.RUNNING.value
+    pod.status.phase = KubernetesPodPhase.RUNNING.value
     event = CoreV1Event(
         metadata=V1ObjectMeta(name=f"{name}-start", namespace=namespace),
         message=f"Pod {name} started",

--- a/tests/services/prepuller_test.py
+++ b/tests/services/prepuller_test.py
@@ -25,7 +25,7 @@ from safir.testing.slack import MockSlackWebhook
 
 from jupyterlabcontroller.config import Config
 from jupyterlabcontroller.factory import Factory
-from jupyterlabcontroller.models.k8s import K8sPodPhase
+from jupyterlabcontroller.models.domain.kubernetes import KubernetesPodPhase
 from jupyterlabcontroller.models.v1.prepuller_config import GARSourceConfig
 
 from ..settings import TestObjectFactory
@@ -61,7 +61,7 @@ async def mark_pod_complete(
             kind="Pod", name=name, namespace=namespace
         ),
     )
-    pod.status.phase = K8sPodPhase.SUCCEEDED.value
+    pod.status.phase = KubernetesPodPhase.SUCCEEDED.value
     await mock_kubernetes.create_namespaced_event(namespace, event)
 
 


### PR DESCRIPTION
Merge the method to wait for a pod to start with the method that monitors events for that pod and eliminate the extra background task for event injection. Use that same method for the prepuller.

Add a new configurable spawn timeout instead of hard-coding it, and pass that timeout into the Kubernetes watch, using a shorter watch for the network connection timeout.

This removes the suppression of duplicate messages, since it's a bit more awkward to do in this format. We can add it back in, but I wanted to try running this version first and see to what degree duplicate messages are an issue.