### PR TITLE
DM-38795: Redo how labs are deleted

### DIFF
--- a/src/jupyterlabcontroller/models/domain/lab.py
+++ b/src/jupyterlabcontroller/models/domain/lab.py
@@ -36,7 +36,7 @@ class UserLab:
     triggers: list[asyncio.Event] = field(default_factory=list)
     """Triggers used to notify event stream listeners of new events."""
 
-    spawner: Optional[asyncio.Task[None]] = None
+    task: Optional[asyncio.Task[None]] = None
     """Background task monitoring the progress of a lab operation.
 
     These tasks are not wrapped in an `aiojobs.Spawner` because the

--- a/src/jupyterlabcontroller/models/v1/event.py
+++ b/src/jupyterlabcontroller/models/v1/event.py
@@ -26,7 +26,7 @@ class Event(BaseModel):
     type: EventType = Field(..., title="Type of the event")
     message: str = Field(..., title="Event message")
     progress: Optional[int] = Field(
-        None, title="Progress percentage", lt=100, gt=0
+        None, title="Progress percentage", le=100, gt=0
     )
 
     @property


### PR DESCRIPTION
Use the same division of labor between LabManager and LabStateManager as for lab creation, which lets us eliminate more public APIs from LabStateManager for the individual events involved in deletion. As with lab spawning, LabStateManager now handles the exceptions, although lab deletion is done in the foreground since JupyterHub does it in the foreground anyway and therefore no purpose is served by adding background deletion.