### PR TITLE
DM-38795: Delete lab on spawn if in failed state

### DIFF
--- a/tests/configs/standard/output/pod-events.json
+++ b/tests/configs/standard/output/pod-events.json
@@ -4,7 +4,7 @@
     "event": "info"
   },
   {
-    "data": "{\"message\": \"Created user namespace\", \"progress\": 5}",
+    "data": "{\"message\": \"Created user namespace\", \"progress\": 10}",
     "event": "info"
   },
   {


### PR DESCRIPTION
If the user already has a lab but that lab is in a failed state, allow them to spawn again and delete the existing lab before creating a new one.