### PR TITLE
DM-38795: Fix lab state reconciliation

### DIFF
--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -1,0 +1,1 @@
+.. _d20 creature sizes: https://www.d20srd.org/srd/combat/movementPositionAndDistance.htm#bigandLittleCreaturesInCombat

--- a/src/jupyterlabcontroller/services/builder.py
+++ b/src/jupyterlabcontroller/services/builder.py
@@ -1,0 +1,108 @@
+"""Construction of Kubernetes objects for user lab environments."""
+
+from __future__ import annotations
+
+from ..config import LabConfig
+
+__all__ = ["LabBuilder"]
+
+
+class LabBuilder:
+    """Construct Kubernetes objects for user lab environments.
+
+    Eventually, this class will be responsible for constructing all of the
+    Kubernetes objects required for a lab environment. Currently, it contains
+    only the Kubernetes object construction code that is shared between
+    `~jupyterlabcontroller.services.lab.LabManager` and
+    `~jupyterlabcontroller.services.state.LabStateManager`.
+
+    Parameters
+    ----------
+    config
+        Lab configuration.
+    """
+
+    def __init__(self, config: LabConfig) -> None:
+        self._config = config
+
+    def build_internal_url(self, username: str, env: dict[str, str]) -> str:
+        """Determine the URL of a newly-spawned lab.
+
+        The hostname and port are fixed to match the Kubernetes ``Service`` we
+        create, but the local part is normally determined by an environment
+        variable passed from JupyterHub.
+
+        Parameters
+        ----------
+        username
+            Username of lab user.
+        env
+            Environment variables from JupyterHub.
+
+        Returns
+        -------
+        str
+            URL of the newly-spawned lab.
+        """
+        namespace = self.namespace_for_user(username)
+        path = env["JUPYTERHUB_SERVICE_PREFIX"]
+        return f"http://lab.{namespace}:8888" + path
+
+    def recreate_env(self, env: dict[str, str]) -> dict[str, str]:
+        """Recreate the JupyterHub-provided environment.
+
+        When reconciling state from Kubernetes, we need to recover the content
+        of the environment sent from JupyterHub from the ``ConfigMap`` in the
+        user's lab environment. We can't recover the exact original
+        environment, but we can recreate an equivalent one by filtering out
+        the environment variables that would be set directly by the lab
+        controller.
+
+        Parameters
+        ----------
+        env
+            Environment recovered from a ``ConfigMap``.
+
+        Returns
+        -------
+        dict of str to str
+            Equivalent environment sent by JupyterHub.
+
+        Notes
+        -----
+        The list of environment variables that are always added internally by
+        the lab controller must be kept in sync with the code that creates the
+        config map.
+        """
+        unwanted = set(
+            (
+                "CPU_GUARANTEE",
+                "CPU_LIMIT",
+                "DEBUG",
+                "EXTERNAL_INSTANCE_URL",
+                "IMAGE_DESCRIPTION",
+                "IMAGE_DIGEST",
+                "JUPYTER_IMAGE",
+                "JUPYTER_IMAGE_SPEC",
+                "MEM_GUARANTEE",
+                "MEM_LIMIT",
+                "RESET_USER_ENV",
+                *list(self._config.env.keys()),
+            )
+        )
+        return {k: v for k, v in env.items() if k not in unwanted}
+
+    def namespace_for_user(self, username: str) -> str:
+        """Construct the namespace name for a user's lab environment.
+
+        Parameters
+        ----------
+        username
+            Username of lab user.
+
+        Returns
+        -------
+        str
+            Name of their namespace.
+        """
+        return f"{self._config.namespace_prefix}-{username}"

--- a/src/jupyterlabcontroller/services/size.py
+++ b/src/jupyterlabcontroller/services/size.py
@@ -41,3 +41,26 @@ class SizeManager:
                 memory=int(memory / LIMIT_TO_REQUEST_RATIO),
             ),
         )
+
+    def size_from_resources(self, resources: UserResources) -> LabSize:
+        """Determine the lab size given the resource constraints.
+
+        This is used by reconciliation of internal data against Kubernetes.
+
+        Parameters
+        ----------
+        resources
+            Discovered lab resources from Kubernetes.
+
+        Returns
+        -------
+        LabSize
+            The corresponding lab size if one of the known sizes matches. If
+            not, returns ``LabSize.custom``.
+        """
+        limits = resources.limits
+        for size, definition in self._sizes.items():
+            memory = memory_string_to_int(definition.memory)
+            if definition.cpu == limits.cpu and memory == limits.memory:
+                return size
+        return LabSize.CUSTOM

--- a/src/jupyterlabcontroller/util.py
+++ b/src/jupyterlabcontroller/util.py
@@ -3,11 +3,3 @@
 
 def deslashify(data: str) -> str:
     return data.replace("/", "_._")
-
-
-def str_to_bool(inp: str) -> bool:
-    """This is OK at detecting False, and everything else is True"""
-    inpl = inp.lower()
-    if inpl in ("f", "false", "n", "no", "off", "0"):
-        return False
-    return True

--- a/tests/configs/standard/output/lab-objects.json
+++ b/tests/configs/standard/output/lab-objects.json
@@ -131,7 +131,9 @@
     "metadata": {
       "annotations": {
         "argocd.argoproj.io/compare-options": "IgnoreExtraneous",
-        "argocd.argoproj.io/sync-options": "Prune=false"
+        "argocd.argoproj.io/sync-options": "Prune=false",
+        "nublado.lsst.io/user-groups": "[{\"name\": \"rachel\", \"id\": 1101}, {\"name\": \"lunatics\", \"id\": 2028}, {\"name\": \"mechanics\", \"id\": 2001}, {\"name\": \"storytellers\", \"id\": 2021}]",
+        "nublado.lsst.io/user-name": "Rachel (?)"
       },
       "labels": {
         "argocd.argoproj.io/instance": "nublado-users",

--- a/tests/services/state_test.py
+++ b/tests/services/state_test.py
@@ -1,0 +1,87 @@
+"""Tests for lab state management.
+
+This is primarily tested through spawning and manipulating labs, mostly via
+the tests of lab routes. The tests performed here are mostly about reconciling
+state with Kubernetes.
+"""
+
+from __future__ import annotations
+
+import pytest
+from safir.testing.kubernetes import MockKubernetesApi
+
+from jupyterlabcontroller.config import Config
+from jupyterlabcontroller.factory import Factory
+from jupyterlabcontroller.models.domain.docker import DockerReference
+from jupyterlabcontroller.models.v1.lab import LabStatus, PodState
+
+from ..settings import TestObjectFactory
+
+
+@pytest.mark.asyncio
+async def test_reconcile(
+    config: Config,
+    factory: Factory,
+    obj_factory: TestObjectFactory,
+    mock_kubernetes: MockKubernetesApi,
+) -> None:
+    for secret in obj_factory.secrets:
+        await mock_kubernetes.create_namespaced_secret(
+            config.lab.namespace_prefix, secret
+        )
+    token, user = obj_factory.get_user()
+    lab = obj_factory.labspecs[0]
+    lab_manager = factory.create_lab_manager()
+    size_manager = factory.create_size_manager()
+    resources = size_manager.resources(lab.options.size)
+    await factory.image_service.refresh()
+    assert lab.options.image_list
+    reference = DockerReference.from_str(lab.options.image_list)
+    image = await factory.image_service.image_for_reference(reference)
+    lab.options.image_list = image.reference_with_digest
+
+    # Create a lab outside of the normal creation flow by calling the internal
+    # methods to create the lab directly. It would be nice to use the
+    # higher-level lab manager function, but it reports events to the lab
+    # state manager, and we want the lab state manager to have no record of
+    # anything to test reconciliation.
+    await lab_manager.create_namespace(user)
+    await lab_manager.create_secrets(user, token)
+    await lab_manager.create_nss(user)
+    await lab_manager.create_file_configmap(user)
+    await lab_manager.create_env(user=user, lab=lab, image=image, token=token)
+    await lab_manager.create_network_policy(user)
+    await lab_manager.create_quota(user)
+    await lab_manager.create_lab_service(user)
+    await lab_manager.create_user_pod(user, resources, image)
+
+    # The lab state manager should think there are no labs.
+    assert await factory.lab_state.list_lab_users() == []
+
+    # Now, start the background reconciliation thread. It should do an initial
+    # reconciliation in the foreground, so when this returns, reconciliation
+    # should be complete.
+    await factory.start_background_services()
+
+    # We should have picked up the manually-created pod and autodiscovered all
+    # of its state.
+    assert await factory.lab_state.list_lab_users() == [user.username]
+    state = await factory.lab_state.get_lab_state(user.username)
+    assert state.dict() == {
+        "env": lab.env,
+        "gid": user.gid,
+        "groups": user.dict()["groups"],
+        "internal_url": (
+            f"http://lab.userlabs-{user.username}:8888/nb/user/rachel/"
+        ),
+        "name": user.name,
+        "options": lab.options.dict(),
+        "pod": PodState.PRESENT,
+        "quota": {"api": {}, "notebook": {"cpu": 9.0, "memory": 27.0}},
+        "resources": resources.dict(),
+        "status": LabStatus.RUNNING,
+        "uid": user.uid,
+        "username": user.username,
+    }
+    status = await factory.lab_state.get_lab_status(user.username)
+    assert status == LabStatus.RUNNING


### PR DESCRIPTION
When the lab controller was restarted, its internal data structures were only partly refreshed from the running labs in Kubernetes. A lot of data was missing or incorrect, such as all of the environment variables. This ran afoul of the new validator to ensure that JUPYTERHUB_SERVICE_PREFIX is set.

Fully restore internal state by also reading the ConfigMap and ResourceQuota objects, and add the data that isn't otherwise easily discernable from lab resources (full name and group name information, which only otherwise exist in the templated NSS files) to annotations on the pod.

This introduces a new LabBuilder object, which eventually will hold all the code to construct Kubernetes objects for a user's lab environment (moved from LabManager, which will then only be about managing lab lifecycle). For the time being, this only holds the methods that need to be shared between LabManager and LabStateManager.