### PR TITLE
DM-38795: Handle conflicts on names of prepuller pods

### DIFF
--- a/src/jupyterlabcontroller/services/prepuller.py
+++ b/src/jupyterlabcontroller/services/prepuller.py
@@ -164,6 +164,7 @@ class Prepuller:
                 namespace=namespace,
                 pod_spec=self._prepull_pod_spec(image, node),
                 owner=self._prepull_pod_owner(),
+                remove_on_conflict=True,
             )
             async for event in self._k8s_client.wait_for_pod(name, namespace):
                 logger.debug(f"Saw pod event: {event.message}")

--- a/tests/configs/standard/output/prepull-conflict-objects.json
+++ b/tests/configs/standard/output/prepull-conflict-objects.json
@@ -1,0 +1,45 @@
+[
+  {
+    "api_version": "v1",
+    "kind": "Pod",
+    "metadata": {
+      "annotations": {
+        "argocd.argoproj.io/compare-options": "IgnoreExtraneous",
+        "argocd.argoproj.io/sync-options": "Prune=false"
+      },
+      "labels": {
+        "argocd.argoproj.io/instance": "nublado-users"
+      },
+      "name": "prepull-d-2077-10-23-node2",
+      "namespace": "userlabs",
+      "owner_references": [
+        {
+          "api_version": "v1",
+          "block_owner_deletion": true,
+          "kind": "Pod",
+          "name": "nublado-controller",
+          "uid": "12720beb-ecae-452e-982e-2f0a0a2fbaf1"
+        }
+      ],
+      "resource_version": "3"
+    },
+    "spec": {
+      "containers": [
+        {
+          "command": [
+            "/bin/sleep",
+            "5"
+          ],
+          "image": "lighthouse.ceres/library/sketchbook:d_2077_10_23@sha256:1234",
+          "name": "prepull",
+          "working_dir": "/tmp"
+        }
+      ],
+      "node_name": "node2",
+      "restart_policy": "Never"
+    },
+    "status": {
+      "phase": "Running"
+    }
+  }
+]


### PR DESCRIPTION
When creating a prepuller pod, if a pod already exists with the same name, remove it first. We may sometimes strand prepuller pods when the lab controller is killed while prepulling (assuming Kubernetes doesn't remove the pods due to their ownership metadata), and it's always safe to recreate those pods.

Also remove prepuller pods in any terminal state, not just success, to reduce the chances we leave stranded pods behind.