### PR TITLE
DM-38795: Handle timeouts consistently

### DIFF
--- a/src/jupyterlabcontroller/exceptions.py
+++ b/src/jupyterlabcontroller/exceptions.py
@@ -31,7 +31,6 @@ __all__ = [
     "SlackWebException",
     "UnknownDockerImageError",
     "UnknownUserError",
-    "WaitingForObjectError",
 ]
 
 
@@ -439,10 +438,6 @@ class KubernetesError(SlackException):
             block = SlackCodeBlock(heading="Error", code=self.body)
             message.blocks.append(block)
         return message
-
-
-class WaitingForObjectError(Exception):
-    """An error occurred while waiting for object creation or deletion."""
 
 
 class MissingSecretError(Exception):


### PR DESCRIPTION
Use TimeoutError for all timeouts instead of our own separate exception. Add timeout handling to lab spawning and deletion, and test that timeout handling works properly.