### PR TITLE
DM-38795: Use a pod watch to wait for pods to start

### DIFF
--- a/src/jupyterlabcontroller/storage/k8s.py
+++ b/src/jupyterlabcontroller/storage/k8s.py
@@ -30,7 +30,6 @@ from kubernetes_asyncio.client import (
     V1ServicePort,
     V1ServiceSpec,
 )
-from safir.datetime import current_datetime
 from structlog.stdlib import BoundLogger
 
 from ..config import LabSecret
@@ -179,7 +178,7 @@ class K8sStorageClient:
         )
 
     async def wait_for_pod(
-        self, pod_name: str, namespace: str, interval: float = 0.5
+        self, pod_name: str, namespace: str
     ) -> KubernetesPodPhase | None:
         """Waits for a pod to finish starting.
 
@@ -194,8 +193,6 @@ class K8sStorageClient:
             Name of the pod.
         namespace
             Namespace in which the pod is located.
-        interval
-            Polling interval.
 
         Returns
         -------
@@ -206,49 +203,60 @@ class K8sStorageClient:
         ------
         KubernetesError
             Raised if there is some failure in a Kubernetes API call.
-
-        Notes
-        -----
-        This should use ``list_namespaced_pod`` with a watch, but temporarily
-        uses polling because it's simpler.
         """
         logger = self._logger.bind(name=pod_name, namespace=namespace)
         logger.debug("Waiting for pod creation")
-        elapsed = timedelta(seconds=0)
-        start = current_datetime()
-        while elapsed < self._spawn_timeout:
-            try:
-                pod = await self.api.read_namespaced_pod_status(
-                    pod_name, namespace
-                )
-            except ApiException as e:
-                if e.status == 404:
-                    delay = int(elapsed.total_seconds())
-                    raise MissingObjectError(
-                        f"Pod does not exist ({delay}s elapsed)",
-                        kind="Pod",
-                        name=pod_name,
-                        namespace=namespace,
-                    )
-                else:
-                    raise KubernetesError.from_exception(
-                        "Error reading pod status",
-                        e,
-                        namespace=namespace,
-                        name=pod_name,
-                    ) from e
-            else:
-                if pod.status.phase not in (
-                    KubernetesPodPhase.UNKNOWN,
-                    KubernetesPodPhase.PENDING,
-                ):
-                    return pod.status.phase
-            await asyncio.sleep(interval)
-            elapsed = current_datetime() - start
+
+        # Retrieve the object first. It's possible that it's already in the
+        # correct phase, and we can return immediately. If not, we want to
+        # start watching events with the next event after the current object
+        # version. Note that we treat Unknown the same as Pending; we rely on
+        # the timeout and otherwise hope that Kubernetes will figure out the
+        # phase.
+        try:
+            pod = await self.api.read_namespaced_pod(pod_name, namespace)
+        except ApiException as e:
+            if e.status == 404:
+                return None
+            raise KubernetesError.from_exception(
+                "Error watching pod startup",
+                e,
+                namespace=namespace,
+                name=pod_name,
+            ) from e
+        if pod.status.phase not in ("Unknown", "Pending"):
+            return KubernetesPodPhase(pod.status.phase)
+
+        # The pod is not in a terminal phase. Start the watch and wait for it
+        # to change state.
+        w = watch.Watch()
+        method = self.api.list_namespaced_pod
+        timeout = int(self._spawn_timeout.total_seconds())
+        watch_args = {
+            "namespace": namespace,
+            "field_selector": f"metadata.name={pod_name}",
+            "resource_version": pod.metadata.resource_version,
+            "timeout_seconds": timeout,
+            "_request_timeout": timeout,
+        }
+        try:
+            async with w.stream(method, **watch_args) as stream:
+                async for event in stream:
+                    if event["type"] == "DELETED":
+                        return None
+                    phase = event["raw_object"]["status"]["phase"]
+                    if phase not in ("Unknown", "Pending"):
+                        return KubernetesPodPhase(phase)
+        except ApiException as e:
+            raise KubernetesError.from_exception(
+                "Error watching pod startup",
+                e,
+                namespace=namespace,
+                name=pod_name,
+            ) from e
 
         # If we fell through, we timed out waiting for the pod to start.
-        msg = "Pod {namespace}/{pod} failed to start in {elapsed}s"
-        raise TimeoutError(msg)
+        raise TimeoutError()
 
     async def watch_pod_events(
         self, pod_name: str, namespace: str
@@ -306,8 +314,6 @@ class K8sStorageClient:
                 namespace=namespace,
                 name=pod_name,
             ) from e
-        finally:
-            w.stop()
 
     async def _handle_pod_event(
         self,

--- a/tests/handlers/labs_test.py
+++ b/tests/handlers/labs_test.py
@@ -319,17 +319,10 @@ async def test_delayed_spawn(
     )
     await mock_kubernetes.create_namespaced_event(namespace, event)
 
-    # Change the pod status to running and add another event.
+    # Change the pod status to running. Do not create another event;
+    # apparently Kubernetes doesn't create events when pods change phase.
     await asyncio.sleep(0.1)
     pod.status.phase = KubernetesPodPhase.RUNNING.value
-    event = CoreV1Event(
-        metadata=V1ObjectMeta(name=f"{name}-start", namespace=namespace),
-        message=f"Pod {name} started",
-        involved_object=V1ObjectReference(
-            kind="Pod", name=name, namespace=namespace
-        ),
-    )
-    await mock_kubernetes.create_namespaced_event(namespace, event)
 
     # The listeners should now complete successfully and we should see
     # appropriate events.
@@ -353,15 +346,6 @@ async def test_delayed_spawn(
                     {
                         "message": "Mounting all the things",
                         "progress": 48,
-                    }
-                ),
-                "event": "info",
-            },
-            {
-                "data": json.dumps(
-                    {
-                        "message": f"Pod nb-{user.username} started",
-                        "progress": 57,
                     }
                 ),
                 "event": "info",

--- a/tests/services/state_test.py
+++ b/tests/services/state_test.py
@@ -176,7 +176,7 @@ async def test_reconcile_pending(
 
     # Wait a little bit for the task to pick up the change and then check to
     # make sure the status updated.
-    await asyncio.sleep(0.1)
+    await asyncio.sleep(0.6)
     state = await factory.lab_state.get_lab_state(user.username)
     expected.status = LabStatus.RUNNING
     assert state.dict() == expected.dict()


### PR DESCRIPTION
Unfortunately, Kubernetes doesn't create an event when a pod changes phase to running, so the approach of only watching Kubernetes namespace events and checking the pod phase when an event is received doesn't work. This required going back to watching the pod phase and the namespace events in separate tasks. The task management of the event watch task is now done by the pod watch task instead of by `LabManager`.