### PR TITLE
DM-38425: Set K8S_NODE_NAME for now

### DIFF
--- a/src/jupyterlabcontroller/services/lab.py
+++ b/src/jupyterlabcontroller/services/lab.py
@@ -784,6 +784,13 @@ class LabManager:
                     field_ref=V1ObjectFieldSelector(field_path="spec.nodeName")
                 ),
             ),
+            # Deprecated, but what lsst.rsp 0.3.4 looks for.
+            V1EnvVar(
+                name="K8S_NODE_NAME",
+                value_from=V1EnvVarSource(
+                    field_ref=V1ObjectFieldSelector(field_path="spec.nodeName")
+                ),
+            ),
         ]
         for spec in self.lab_config.secrets:
             if not spec.env:

--- a/tests/configs/standard/output/lab-objects.json
+++ b/tests/configs/standard/output/lab-objects.json
@@ -169,6 +169,14 @@
               }
             },
             {
+              "name": "K8S_NODE_NAME",
+              "value_from": {
+                "field_ref": {
+                  "field_path": "spec.nodeName"
+                }
+              }
+            },
+            {
               "name": "BUTLER_SECRET",
               "value_from": {
                 "secret_key_ref": {


### PR DESCRIPTION
lsst.rsp already looks for the environment variable K8S_NODE_NAME, so while we want to avoid confusing abbreviations, we need to set both that and KUBERNETES_NODE_NAME for now until lsst.rsp has been updated and rolled out in a new weekly and recommended.