### PR TITLE
DM-39249: Fix JavaScript for selecting images from dropdown

### DIFF
--- a/src/jupyterlabcontroller/assets/form_template.txt
+++ b/src/jupyterlabcontroller/assets/form_template.txt
@@ -37,7 +37,7 @@ function selectDropdown() {
     <label for="{{ dropdown_sentinel }}">
       Select uncached image (slower start):
     </label><br />
-    <select name="image_dropdown" onclick="selectDropdown()">
+    <select name="image_dropdown" onchange="selectDropdown()">
 {% for i in all_images -%}
         <option value="{{ i.reference }}">{{ i.name }}</option>
 {% endfor %}

--- a/tests/configs/standard/output/lab_form.txt
+++ b/tests/configs/standard/output/lab_form.txt
@@ -34,7 +34,7 @@ function selectDropdown() {
     <label for="use_image_from_dropdown">
       Select uncached image (slower start):
     </label><br />
-    <select name="image_dropdown" onclick="selectDropdown()">
+    <select name="image_dropdown" onchange="selectDropdown()">
 <option value="lighthouse.ceres/library/sketchbook:recommended@sha256:5678">Recommended (Weekly 2077_43)</option>
 <option value="lighthouse.ceres/library/sketchbook:w_2077_43@sha256:5678">Weekly 2077_43</option>
 <option value="lighthouse.ceres/library/sketchbook:d_2077_10_23@sha256:1234">Daily 2077_10_23</option>


### PR DESCRIPTION
In order to move the selection to the dropdown when an image was selected from the dropdown, we were using the onclick attribute of the <select> element. This appears to not work correctly with Safari. Change it to onchange, which hopefully will.

See https://stackoverflow.com/questions/1769374/