### PR TITLE
DM-39232: Add support for subPath in volume mounts

### DIFF
--- a/src/jupyterlabcontroller/config.py
+++ b/src/jupyterlabcontroller/config.py
@@ -174,6 +174,11 @@ class LabVolume(CamelCaseModel):
         title="Absolute path of the volume mounted inside the Lab container",
         regex="^/.*",
     )
+    sub_path: str | None = Field(
+        None,
+        example="groups",
+        title="Mount only this subpath of the volume source",
+    )
     mode: FileMode = Field(
         FileMode.RW,
         example="ro",

--- a/src/jupyterlabcontroller/services/builder.py
+++ b/src/jupyterlabcontroller/services/builder.py
@@ -166,6 +166,7 @@ class LabBuilder:
                     vol = V1Volume(persistent_volume_claim=claim, name=vname)
             vm = V1VolumeMount(
                 mount_path=prefix + storage.container_path,
+                sub_path=storage.sub_path,
                 read_only=ro,
                 name=vname,
             )

--- a/tests/configs/standard/input/config.yaml
+++ b/tests/configs/standard/input/config.yaml
@@ -176,6 +176,17 @@ lab:
         resources:
           requests:
             storage: 1Gi
+    - containerPath: /temporary
+      subPath: temporary
+      mode: rw
+      source:
+        type: persistentVolumeClaim
+        storageClassName: sdf-home
+        accessModes:
+          - ReadWriteMany
+        resources:
+          requests:
+            storage: 1Gi
 fileserver:
   image: docker.io/lsstsqre/worblehat
   tag: ajt-dev

--- a/tests/configs/standard/output/lab-objects.json
+++ b/tests/configs/standard/output/lab-objects.json
@@ -159,6 +159,33 @@
   },
   {
     "api_version": "v1",
+    "kind": "PersistentVolumeClaim",
+    "metadata": {
+      "annotations": {
+        "argocd.argoproj.io/compare-options": "IgnoreExtraneous",
+        "argocd.argoproj.io/sync-options": "Prune=false"
+      },
+      "labels": {
+        "argocd.argoproj.io/instance": "nublado-users",
+        "nublado.lsst.io/category": "lab"
+      },
+      "name": "rachel-nb-pvc-2",
+      "namespace": "userlabs-rachel"
+    },
+    "spec": {
+      "access_modes": [
+        "ReadWriteMany"
+      ],
+      "resources": {
+        "requests": {
+          "storage": "1Gi"
+        }
+      },
+      "storage_class_name": "sdf-home"
+    }
+  },
+  {
+    "api_version": "v1",
     "kind": "Pod",
     "metadata": {
       "annotations": {
@@ -266,6 +293,12 @@
               "mount_path": "/scratch",
               "name": "scratch",
               "read_only": false
+            },
+            {
+              "mount_path": "/temporary",
+              "name": "temporary",
+              "read_only": false,
+              "sub_path": "temporary"
             },
             {
               "mount_path": "/etc/passwd",
@@ -401,6 +434,13 @@
           "name": "scratch",
           "persistent_volume_claim": {
             "claim_name": "nb-rachel-pvc-1",
+            "read_only": false
+          }
+        },
+        {
+          "name": "temporary",
+          "persistent_volume_claim": {
+            "claim_name": "nb-rachel-pvc-2",
             "read_only": false
           }
         },


### PR DESCRIPTION
USDF dev mounts a volume in one place and a subpath of the same volume in a different place. Add support for specifying a subPath in the volume list.

This is not entirely correct since we still generate two PVCs for the same storage, which I think will work at the USDF because everything is ReadWriteMany, but which would fail with ReadWriteOnce. However, the more correct solution requires a more intrusive configuration change to support mounting the same volume in multiple places, which I'm deferring for later work.