### PR TITLE
DM-39249: Work around a per-event-loop lock in sse-starlette

### DIFF
--- a/requirements/main.in
+++ b/requirements/main.in
@@ -21,7 +21,7 @@ jinja2
 PyYAML
 safir[kubernetes]>=4.3.0
 semver
-sse-starlette!=1.6.1
+sse-starlette
 
 # Uncomment this, change the branch, comment out safir above, and run make
 # update-deps-no-hashes to test against an unreleased version of Safir.

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -946,9 +946,9 @@ sniffio==1.3.0 \
     #   anyio
     #   httpcore
     #   httpx
-sse-starlette==1.6.0 \
-    --hash=sha256:14dfde4d5c8e319251655800c4efcae581b2283503ece3826a62d92975e997ff \
-    --hash=sha256:b9cb77cd61a686466105171090a050a42df45ff76d6034f6668b1bca7dba55fb
+sse-starlette==1.6.1 \
+    --hash=sha256:6208af2bd7d0887c92f1379da14bd1f4db56bd1274cc5d36670c683d2aa1de6a \
+    --hash=sha256:d8f18f1c633e355afe61cc5e9c92eea85badcb8b2d56ec8cfb0a006994aa55da
     # via -r requirements/main.in
 starlette==0.27.0 \
     --hash=sha256:6a6b0d042acb8d469a01eba54e9cda6cbd24ac602c4cd016723117d6a7e73b75 \


### PR DESCRIPTION
sse-starlette initializes itself on first use with a process-global lock that's bound to the current event loop, which caused tests to fail when each test was run under a separate event loop. Clean up this lock on server shutdown to avoid this problem.