### PR TITLE
DM-39400: Improve Kubernetes exception reporting

### DIFF
--- a/src/jupyterlabcontroller/services/fileserver.py
+++ b/src/jupyterlabcontroller/services/fileserver.py
@@ -406,10 +406,9 @@ class FileserverStateManager:
             self._config.fileserver.namespace
         ):
             raise MissingObjectError(
-                message=(
-                    "No namespace " + f"'{self._config.fileserver.namespace}'"
-                ),
-                kind="namespace",
+                "File server namespace missing",
+                kind="Namespace",
+                name=self._config.fileserver.namespace,
             )
         await self._reconcile_user_map()
         self._started = True

--- a/tests/handlers/labs_test.py
+++ b/tests/handlers/labs_test.py
@@ -549,53 +549,53 @@ async def test_spawn_errors(
         (
             "create_namespace",
             "creating user namespace",
-            "userlabs-rachel",
             "Namespace",
+            "userlabs-rachel",
         ),
         (
             "read_namespaced_secret",
-            "reading secret",
-            "userlabs/nublado-secret",
+            "reading object",
             "Secret",
+            "userlabs/nublado-secret",
         ),
         (
             "create_namespaced_secret",
-            "creating secret",
-            "userlabs-rachel/rachel-nb",
+            "creating object",
             "Secret",
+            "userlabs-rachel/rachel-nb",
         ),
         (
             "create_namespaced_config_map",
-            "creating config map",
-            "userlabs-rachel/rachel-nb-nss",
+            "creating object",
             "ConfigMap",
+            "userlabs-rachel/rachel-nb-nss",
         ),
         (
             "create_namespaced_network_policy",
-            "creating network policy",
-            "userlabs-rachel/rachel-nb-env",
+            "creating object",
             "NetworkPolicy",
+            "userlabs-rachel/rachel-nb-env",
         ),
         (
             "create_namespaced_resource_quota",
-            "creating resource quota",
-            "userlabs-rachel/rachel-nb",
+            "creating object",
             "ResourceQuota",
+            "userlabs-rachel/rachel-nb",
         ),
         (
             "create_namespaced_service",
-            "creating service",
-            "userlabs-rachel/lab",
+            "creating object",
             "Service",
+            "userlabs-rachel/lab",
         ),
         (
             "create_namespaced_pod",
-            "creating pod",
-            "userlabs-rachel/rachel-nb",
+            "creating object",
             "Pod",
+            "userlabs-rachel/rachel-nb",
         ),
     ]
-    for api, error, obj, kind in possible_errors:
+    for api, error, kind, obj in possible_errors:
         apis_to_fail = {api}
         r = await client.post(
             f"/nublado/spawner/v1/labs/{user.username}/create",
@@ -607,7 +607,7 @@ async def test_spawn_errors(
         )
         assert r.status_code == 201
         events = await get_lab_events(client, user.username)
-        error = f"Error {error} ({obj}, status 400)"
+        error = f"Error {error} ({kind} {obj}, status 400)"
         assert events[-2] == {
             "data": json.dumps(
                 {"message": f"{error}: Something bad happened"}
@@ -644,16 +644,19 @@ async def test_spawn_errors(
                                 "verbatim": True,
                             },
                             {
-                                "text": f"*Object*\n[{kind}] {obj}",
-                                "type": "mrkdwn",
-                                "verbatim": True,
-                            },
-                            {
                                 "text": "*Status*\n400",
                                 "type": "mrkdwn",
                                 "verbatim": True,
                             },
                         ],
+                    },
+                    {
+                        "type": "section",
+                        "text": {
+                            "text": f"*Object*\n{kind} {obj}",
+                            "type": "mrkdwn",
+                            "verbatim": True,
+                        },
                     },
                     {
                         "type": "section",

--- a/tests/services/prepuller_test.py
+++ b/tests/services/prepuller_test.py
@@ -288,7 +288,7 @@ async def test_kubernetes_error(
     await asyncio.sleep(0.2)
 
     obj = "userlabs/prepull-d-2077-10-23-node2"
-    error = f"Error creating pod ({obj}, status 400)"
+    error = f"Error creating object (Pod {obj}, status 400)"
     assert mock_slack.messages == [
         {
             "blocks": [
@@ -310,16 +310,19 @@ async def test_kubernetes_error(
                         },
                         {"text": ANY, "type": "mrkdwn", "verbatim": True},
                         {
-                            "text": f"*Object*\n[Pod] {obj}",
-                            "type": "mrkdwn",
-                            "verbatim": True,
-                        },
-                        {
                             "text": "*Status*\n400",
                             "type": "mrkdwn",
                             "verbatim": True,
                         },
                     ],
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "text": f"*Object*\nPod {obj}",
+                        "type": "mrkdwn",
+                        "verbatim": True,
+                    },
                 },
                 {
                     "type": "section",


### PR DESCRIPTION
Move the Kubernetes object from a Slack field to a block, since it's too long for a field. Remove the brackets around the kind, since it seems reasonably clear without them. Add the kind to the exception summary as well, and handle a few more formatting edge cases.

KubernetesError was used in a couple of places that weren't Kubernetes API errors. Switch them to either MissingObjectError or a new DuplicateObjectError, and also improve the Slack formatting of those exceptions.

Reorder parameters to follow a more natural naming order of kind, namespace, name (from least specific to most specific), except for the methods that take a name and a namespace, where we keep the annoying Kubernetes API order of name, namespace to avoid confusion.