### PR TITLE
DM-39400: Handle groups without GIDs

### DIFF
--- a/src/jupyterlabcontroller/models/v1/lab.py
+++ b/src/jupyterlabcontroller/models/v1/lab.py
@@ -334,7 +334,7 @@ class UserInfo(BaseModel):
             name=user.name,
             uid=user.uid,
             gid=user.gid,
-            groups=user.groups,
+            groups=[g for g in user.groups if g.id],
         )
 
 

--- a/tests/configs/standard/input/test_objects.json
+++ b/tests/configs/standard/input/test_objects.json
@@ -9,7 +9,8 @@
         {"name": "rachel", "id": 1101},
         {"name": "lunatics", "id": 2028},
         {"name": "mechanics", "id": 2001},
-        {"name": "storytellers", "id": 2021}
+        {"name": "storytellers", "id": 2021},
+        {"name": "explorers"}
       ],
       "quota": {
         "notebook": {

--- a/tests/handlers/labs_test.py
+++ b/tests/handlers/labs_test.py
@@ -158,7 +158,7 @@ async def test_lab_start_stop(
             "name": user.name,
             "uid": user.uid,
             "gid": user.gid,
-            "groups": user.dict()["groups"],
+            "groups": [g.dict() for g in user.groups if g.id],
         },
     }
     assert r.json() == expected

--- a/tests/handlers/user_status_test.py
+++ b/tests/handlers/user_status_test.py
@@ -81,7 +81,7 @@ async def test_user_status(
             "name": user.name,
             "uid": user.uid,
             "gid": user.gid,
-            "groups": user.dict()["groups"],
+            "groups": [g.dict() for g in user.groups if g.id],
         },
     }
     assert r.json() == expected


### PR DESCRIPTION
Gafaelfawr allows the user to be a member of a group with no GID, but this should be ignored for Nublado controller purposes since we can't do anything useful with such groups. Filter them out when constructing the lab and when constructing the user metadata portion of the lab status.

Take advantage of the opportunity to refactor the method that generates the NSS ConfigMap.