### PR TITLE
tickets/DM-40183: fix incorrect homedir creation at USDF

### DIFF
--- a/src/jupyterlabcontroller/services/lab.py
+++ b/src/jupyterlabcontroller/services/lab.py
@@ -877,9 +877,6 @@ class LabManager:
             image_pull_secrets=pull_secrets,
             restart_policy="OnFailure",
             security_context=V1PodSecurityContext(
-                run_as_non_root=True,
-                run_as_user=user.uid,
-                run_as_group=user.gid,
                 supplemental_groups=[x.id for x in user.groups if x.id],
             ),
             volumes=volumes,

--- a/src/jupyterlabcontroller/services/lab.py
+++ b/src/jupyterlabcontroller/services/lab.py
@@ -831,7 +831,6 @@ class LabManager:
             env.append(env_var)
 
         # Specification for the user's container.
-        homedir = self._get_homedir(user)
         container = V1Container(
             name="notebook",
             args=["/opt/lsst/software/jupyterlab/runlab.sh"],
@@ -862,7 +861,7 @@ class LabManager:
                 run_as_group=user.gid,
             ),
             volume_mounts=mounts,
-            working_dir=homedir,
+            working_dir=self._get_homedir(user),
         )
 
         # Build the pod specification itself.

--- a/src/jupyterlabcontroller/services/lab.py
+++ b/src/jupyterlabcontroller/services/lab.py
@@ -878,7 +878,8 @@ class LabManager:
             restart_policy="OnFailure",
             security_context=V1PodSecurityContext(
                 run_as_non_root=True,
-                fs_group=user.gid,
+                run_as_user=user.uid,
+                run_as_group=user.gid,
                 supplemental_groups=[x.id for x in user.groups if x.id],
             ),
             volumes=volumes,

--- a/tests/configs/standard/output/lab-objects.json
+++ b/tests/configs/standard/output/lab-objects.json
@@ -407,8 +407,9 @@
       ],
       "restart_policy": "OnFailure",
       "security_context": {
-        "fs_group": 1101,
+        "run_as_group": 1101,
         "run_as_non_root": true,
+	"run_as_user": 1101,
         "supplemental_groups": [
           1101,
           2028,

--- a/tests/configs/standard/output/lab-objects.json
+++ b/tests/configs/standard/output/lab-objects.json
@@ -407,9 +407,6 @@
       ],
       "restart_policy": "OnFailure",
       "security_context": {
-        "run_as_group": 1101,
-        "run_as_non_root": true,
-	"run_as_user": 1101,
         "supplemental_groups": [
           1101,
           2028,

--- a/tests/handlers/working_dir_test.py
+++ b/tests/handlers/working_dir_test.py
@@ -1,0 +1,48 @@
+import pytest
+from httpx import AsyncClient
+from safir.testing.kubernetes import MockKubernetesApi
+
+from jupyterlabcontroller.dependencies.context import context_dependency
+
+from ..settings import TestObjectFactory
+from ..support.config import configure
+
+
+@pytest.mark.asyncio
+async def test_pod_working_dir(
+    client: AsyncClient,
+    mock_kubernetes: MockKubernetesApi,
+    obj_factory: TestObjectFactory,
+) -> None:
+    """Check that the pod working directory uses the right home directory.
+
+    Earlier versions had a bug where the working directory for the spawned pod
+    was always :file:`/home/{username}` even if another home directory rule
+    was set.
+    """
+    token, user = obj_factory.get_user()
+    lab = obj_factory.labspecs[0]
+
+    # Reconfigure the app to use a different home directory scheme.
+    await context_dependency.aclose()
+    config = configure("homedir-schema")
+    await context_dependency.initialize(config)
+
+    r = await client.post(
+        f"/nublado/spawner/v1/labs/{user.username}/create",
+        json={"options": lab.options.dict(), "env": lab.env},
+        headers={
+            "X-Auth-Request-Token": token,
+            "X-Auth-Request-User": user.username,
+        },
+    )
+    assert r.status_code == 201
+
+    namespace = f"{config.lab.namespace_prefix}-{user.username}"
+    pod_name = f"{user.username}-nb"
+    pod = await mock_kubernetes.read_namespaced_pod(pod_name, namespace)
+    for container in pod.spec.containers:
+        assert (
+            container.working_dir
+            == f"/home/{user.username[0]}/{user.username}"
+        )

--- a/tests/services/homedir_test.py
+++ b/tests/services/homedir_test.py
@@ -12,7 +12,7 @@ from ..support.data import read_output_data
 
 
 @pytest.mark.asyncio
-async def test_homedir_schema(obj_factory: TestObjectFactory) -> None:
+async def test_homedir_schema_nss(obj_factory: TestObjectFactory) -> None:
     """Test building a passwd file with the alternate homedir layout."""
     _, user = obj_factory.get_user()
     config = configure("homedir-schema")

--- a/tests/services/homedir_test.py
+++ b/tests/services/homedir_test.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import pytest
 
 from jupyterlabcontroller.factory import Factory
+from jupyterlabcontroller.models.domain.rspimage import RSPImage
+from jupyterlabcontroller.models.domain.rsptag import RSPImageTag
+from jupyterlabcontroller.models.v1.lab import LabResources, ResourceQuantity
 
 from ..settings import TestObjectFactory
 from ..support.config import configure
@@ -22,3 +25,40 @@ async def test_homedir_schema_nss(obj_factory: TestObjectFactory) -> None:
         lm = factory.create_lab_manager()
         nss = lm.build_nss(user)
         assert nss == expected_nss
+
+
+@pytest.mark.asyncio
+async def test_homedir_schema_pod(obj_factory: TestObjectFactory) -> None:
+    """Test building a pod spec with the alternate homedir layout and make
+    sure `working_dir` is correctly set."""
+    _, user = obj_factory.get_user()
+    config = configure("homedir-schema")
+
+    async with Factory.standalone(config) as factory:
+        # We will construct image and resources fairly directly, rather than
+        # going through the layers to get them 'legitimately'
+        contents = obj_factory.test_objects["user_options"][0]["image_list"]
+        tag = RSPImageTag.from_str(contents)
+        registry, repo, rest = contents.split("/")
+        ttag, digest = rest.split("@")
+        image = RSPImage(
+            registry=registry,
+            repository=repo,
+            digest=digest,
+            size=None,
+            aliases=set(),
+            version=None,
+            cycle=None,
+            tag=ttag,
+            image_type=tag.image_type,
+            display_name=ttag,
+        )
+        resources = LabResources(
+            limits=ResourceQuantity(cpu=1.0, memory=4294967296),
+            requests=ResourceQuantity(cpu=0.25, memory=1073741824),
+        )
+        lm = factory.create_lab_manager()
+        podspec = lm.build_pod_spec(user, resources, image)
+        # The Pod spec isn't JSON-serializable, so we will just check the
+        # field we care about rather than comparing the objects.
+        assert podspec.containers[0].working_dir == "/home/r/rachel"

--- a/tests/services/homedir_test.py
+++ b/tests/services/homedir_test.py
@@ -5,9 +5,6 @@ from __future__ import annotations
 import pytest
 
 from jupyterlabcontroller.factory import Factory
-from jupyterlabcontroller.models.domain.rspimage import RSPImage
-from jupyterlabcontroller.models.domain.rsptag import RSPImageTag
-from jupyterlabcontroller.models.v1.lab import LabResources, ResourceQuantity
 
 from ..settings import TestObjectFactory
 from ..support.config import configure
@@ -25,40 +22,3 @@ async def test_homedir_schema_nss(obj_factory: TestObjectFactory) -> None:
         lm = factory.create_lab_manager()
         nss = lm.build_nss(user)
         assert nss == expected_nss
-
-
-@pytest.mark.asyncio
-async def test_homedir_schema_pod(obj_factory: TestObjectFactory) -> None:
-    """Test building a pod spec with the alternate homedir layout and make
-    sure `working_dir` is correctly set."""
-    _, user = obj_factory.get_user()
-    config = configure("homedir-schema")
-
-    async with Factory.standalone(config) as factory:
-        # We will construct image and resources fairly directly, rather than
-        # going through the layers to get them 'legitimately'
-        contents = obj_factory.test_objects["user_options"][0]["image_list"]
-        tag = RSPImageTag.from_str(contents)
-        registry, repo, rest = contents.split("/")
-        ttag, digest = rest.split("@")
-        image = RSPImage(
-            registry=registry,
-            repository=repo,
-            digest=digest,
-            size=None,
-            aliases=set(),
-            version=None,
-            cycle=None,
-            tag=ttag,
-            image_type=tag.image_type,
-            display_name=ttag,
-        )
-        resources = LabResources(
-            limits=ResourceQuantity(cpu=1.0, memory=4294967296),
-            requests=ResourceQuantity(cpu=0.25, memory=1073741824),
-        )
-        lm = factory.create_lab_manager()
-        podspec = lm.build_pod_spec(user, resources, image)
-        # The Pod spec isn't JSON-serializable, so we will just check the
-        # field we care about rather than comparing the objects.
-        assert podspec.containers[0].working_dir == "/home/r/rachel"


### PR DESCRIPTION
At USDF, despite our homedir_schema setting, we're creating /home/<username>

I believe this fixes the issue, although I'm not going to merge until I've done some testing at USDF-dev.

The cause appears to be 1) not setting run_as_user in the pod spec, so despite the fact that you end up as the right user with the right groups, it starts with enough privilege to create the directory), which 2) is set as working_dir in the pod spec.

So I've corrected these two things.

In an idea world we would have a test for the pod spec being correct when a non-default homedir_schema is in effect, but we didn't make it easy to unit test pod spec creation, which (necessarily) relies on resolved RSPImages, and therefore needs a bunch of new helper methods defined, or an end-to-end handler test (which might actually be easier) checking on the created pod.  I wanted to get USDF out of its current pickle quickly, and implementing the test is going to take some thought and time.