### PR TITLE
tickets/DM-40454: If we have a pull secret, add it to the prepuller too

### DIFF
--- a/src/jupyterlabcontroller/factory.py
+++ b/src/jupyterlabcontroller/factory.py
@@ -140,6 +140,7 @@ class ProcessContext:
                 image_service=image_service,
                 k8s_client=k8s_client,
                 slack_client=slack_client,
+                pull_secret=config.lab.pull_secret,
                 logger=logger,
             ),
             lab_state=LabStateManager(

--- a/tests/configs/standard/output/prepull-conflict-objects.json
+++ b/tests/configs/standard/output/prepull-conflict-objects.json
@@ -35,6 +35,9 @@
           "working_dir": "/tmp"
         }
       ],
+      "image_pull_secrets": [
+	{ "name": "pull-secret" }
+      ],
       "node_name": "node2",
       "restart_policy": "Never"
     },

--- a/tests/configs/standard/output/prepull-objects.json
+++ b/tests/configs/standard/output/prepull-objects.json
@@ -35,6 +35,9 @@
           "working_dir": "/tmp"
         }
       ],
+      "image_pull_secrets": [
+	{ "name": "pull-secret" }
+      ],
       "node_name": "node2",
       "restart_policy": "Never"
     },


### PR DESCRIPTION
T&S needs this, but we should have generically been doing it all along.  If we need a pull secret for lab images, and since the prepuller is by definition using the images, then the prepuller should get that secret if it exists.