### PR TITLE
DM-40691: Add new JobStorage and IngressStorage classes

### DIFF
--- a/src/jupyterlabcontroller/models/domain/kubernetes.py
+++ b/src/jupyterlabcontroller/models/domain/kubernetes.py
@@ -20,6 +20,7 @@ __all__ = [
     "KubernetesPodWatchInfo",
     "KubernetesKindMethodContainer",
     "KubernetesKindMethodMapper",
+    "PropagationPolicy",
     "WatchEventType",
     "get_watch_args",
 ]
@@ -34,6 +35,14 @@ class KubernetesModel(Protocol):
     """
 
     metadata: V1ObjectMeta
+
+
+class PropagationPolicy(Enum):
+    """Possible values for the ``propagationPolicy`` parameter to delete."""
+
+    FOREGROUND = "Foreground"
+    BACKGROUND = "Background"
+    ORPHAN = "Orphan"
 
 
 class WatchEventType(Enum):

--- a/src/jupyterlabcontroller/services/fileserver.py
+++ b/src/jupyterlabcontroller/services/fileserver.py
@@ -105,9 +105,7 @@ class FileserverStateManager:
                 username, namespace, spec=gf_ingress
             )
             self._logger.debug(f"...creating new job for {username}")
-            await self._k8s_client.create_fileserver_job(
-                username, namespace, job
-            )
+            await self._k8s_client.create_fileserver_job(namespace, job)
             self._logger.debug(f"...creating new service for {username}")
             await self._k8s_client.create_fileserver_service(
                 namespace, service
@@ -140,7 +138,9 @@ class FileserverStateManager:
         await self._k8s_client.wait_for_user_fileserver_ingress_ready(
             username,
             namespace,
-            timeout=self._config.fileserver.creation_timeout,
+            timeout=timedelta(
+                seconds=self._config.fileserver.creation_timeout
+            ),
         )
 
     def _build_metadata(self, username: str) -> V1ObjectMeta:

--- a/src/jupyterlabcontroller/storage/kubernetes/ingress.py
+++ b/src/jupyterlabcontroller/storage/kubernetes/ingress.py
@@ -1,0 +1,113 @@
+"""Storage layer for ``Ingress`` objects."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from kubernetes_asyncio import client
+from kubernetes_asyncio.client import ApiClient, V1Ingress
+from structlog.stdlib import BoundLogger
+
+from ...models.domain.kubernetes import WatchEventType
+from .deleter import KubernetesObjectDeleter
+from .watcher import KubernetesWatcher
+
+__all__ = ["IngressStorage"]
+
+
+class IngressStorage(KubernetesObjectDeleter):
+    """Storage layer for ``Ingress`` objects.
+
+    Parameters
+    ----------
+    api_client
+        Kubernetes API client.
+    logger
+        Logger to use.
+    """
+
+    def __init__(self, api_client: ApiClient, logger: BoundLogger) -> None:
+        api = client.NetworkingV1Api(api_client)
+        super().__init__(
+            create_method=api.create_namespaced_ingress,
+            delete_method=api.delete_namespaced_ingress,
+            list_method=api.list_namespaced_ingress,
+            read_method=api.read_namespaced_ingress,
+            object_type=V1Ingress,
+            kind="Ingress",
+            logger=logger,
+        )
+
+    def has_ip_address(self, ingress: V1Ingress) -> bool:
+        """Check whether an ingress has an IP address assigned.
+
+        Parameters
+        ----------
+        ingress
+            Ingress to check.
+
+        Returns
+        -------
+        bool
+            `True` if an IP address is assigned, `False` otherwise.
+        """
+        if not ingress.status:
+            return False
+        if not ingress.status.load_balancer:
+            return False
+        if not ingress.status.load_balancer.ingress:
+            return False
+        return bool(ingress.status.load_balancer.ingress[0].ip)
+
+    async def wait_for_ip_address(
+        self, name: str, namespace: str, timeout: timedelta
+    ) -> None:
+        """Wait for an ingress to get an IP address assigned.
+
+        The ``Ingress`` object is allowed to not exist when the watch starts,
+        since it may be created from a ``GafaelfawrIngress`` custom object.
+
+        Parameters
+        ----------
+        name
+            Name of the ingress.
+        namespace
+            Namespace of the ingress.
+        timeout
+            How long to wait for the IP address to be assigned.
+
+        Raises
+        ------
+        KubernetesError
+            Raised for exceptions from the Kubernetes API server.
+        TimeoutError
+            Raised if the object is not deleted within the delete timeout.
+        """
+        ingress = await self.read(name, namespace)
+        resource_version = None
+        if ingress:
+            if self.has_ip_address(ingress):
+                return
+            resource_version = ingress.metadata.resource_version
+
+        # Watch ingress events and wait for it to get an IP address.
+        watcher = KubernetesWatcher(
+            method=self._list,
+            object_type=self._type,
+            kind=self._kind,
+            name=name,
+            namespace=namespace,
+            resource_version=resource_version,
+            timeout=timeout,
+            logger=self._logger,
+        )
+        try:
+            async for event in watcher.watch():
+                if event.action != WatchEventType.DELETED:
+                    if self.has_ip_address(event.object):
+                        return
+        finally:
+            await watcher.close()
+
+        # This should be impossible; someone called stop on the watcher.
+        raise RuntimeError("Wait for ingress IP unexpectedly stopped")

--- a/tests/configs/fileserver/input/config.yaml
+++ b/tests/configs/fileserver/input/config.yaml
@@ -39,6 +39,7 @@ images:
   numDailies: 3
 fileserver:
   enabled: true
+  creationTimeout: 1
   namespace: fileservers
   image: ghcr.io/lsst-sqre/worblehat
 


### PR DESCRIPTION
Replace the Kubernetes job manipulation classes with a JobStorage class that inherits from KubernetesObjectDeleter. Add propagation_policy support to the standard delete method to support its usage with jobs.

Replace the Kubernetes ingress calls with a new-style IngressStorage class. This inherits the standard functionality from the generic KubernetesObjectDeleter class, but adds a method to check whether an ingress has an IP address assigned and a method to wait for an ingress to appear and get an IP address.

This uncovered a bug that meant that the code waiting for the ingress and job to be deleted was doing nothing due to a missing f in an f-string. Fixing that in turn required some changes to the test suite, since it was often not deleting the ingress until after the controller was waiting for the ingress to go away.