### PR TITLE
DM-40691: Add a new pod storage layer

### DIFF
--- a/src/jupyterlabcontroller/factory.py
+++ b/src/jupyterlabcontroller/factory.py
@@ -15,7 +15,6 @@ from safir.slack.webhook import SlackWebhookClient
 from structlog.stdlib import BoundLogger
 
 from .config import Config
-from .constants import KUBERNETES_REQUEST_TIMEOUT
 from .models.v1.prepuller_config import DockerSourceConfig, GARSourceConfig
 from .services.builder import LabBuilder
 from .services.fileserver import FileserverStateManager
@@ -91,9 +90,7 @@ class ProcessContext:
 
         k8s_client = K8sStorageClient(
             kubernetes_client=kubernetes_client,
-            timeout=KUBERNETES_REQUEST_TIMEOUT,
             spawn_timeout=config.lab.spawn_timeout,
-            fileserver_creation_timeout=config.fileserver.creation_timeout,
             logger=logger,
         )
 
@@ -315,9 +312,7 @@ class Factory:
         config = self._context.config
         k8s_client = K8sStorageClient(
             kubernetes_client=self._context.kubernetes_client,
-            timeout=KUBERNETES_REQUEST_TIMEOUT,
             spawn_timeout=config.lab.spawn_timeout,
-            fileserver_creation_timeout=config.fileserver.creation_timeout,
             logger=self._logger,
         )
         return LabManager(

--- a/src/jupyterlabcontroller/models/domain/kubernetes.py
+++ b/src/jupyterlabcontroller/models/domain/kubernetes.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Coroutine, Optional, Self
+from typing import Self
 
-from kubernetes_asyncio.client import V1ContainerImage, V1ObjectMeta, V1Pod
+from kubernetes_asyncio.client import V1ContainerImage, V1ObjectMeta
 from typing_extensions import Protocol
 
 from .docker import DockerReference
@@ -14,15 +14,9 @@ from .docker import DockerReference
 __all__ = [
     "KubernetesModel",
     "KubernetesNodeImage",
-    "KubernetesPodEvent",
     "KubernetesPodPhase",
-    "KubernetesEvent",
-    "KubernetesPodWatchInfo",
-    "KubernetesKindMethodContainer",
-    "KubernetesKindMethodMapper",
     "PropagationPolicy",
     "WatchEventType",
-    "get_watch_args",
 ]
 
 
@@ -118,110 +112,3 @@ class KubernetesPodPhase(str, Enum):
     SUCCEEDED = "Succeeded"
     FAILED = "Failed"
     UNKNOWN = "Unknown"
-
-
-@dataclass
-class KubernetesPodEvent:
-    """Represents an event seen while waiting for pod startup."""
-
-    message: str
-    """Message in the Kubernetes event."""
-
-    phase: KubernetesPodPhase
-    """Current phase of the pod."""
-
-    error: Optional[str] = None
-    """Additional error accompanying this event (usually from the pod)."""
-
-    @property
-    def done(self) -> bool:
-        """`True` if the pod has started or definitively failed to start.
-
-        An unknown phase is considered a failure. The Kubernetes documentation
-        says that this can happen when the node on which the pod is supposed
-        to be running cannot be contacted, which is a sufficiently broken
-        state that we should consider the spawn a failure rather than waiting
-        to hope it will fix itself.
-        """
-        return self.phase != KubernetesPodPhase.PENDING
-
-
-@dataclass
-class KubernetesEvent:
-    """Repackaging of yielded event to regularize some fields."""
-
-    type: str
-    object: dict[str, Any]
-    kind: str
-    name: str
-    namespace: Optional[str]
-
-    @classmethod
-    def from_event(cls, event: dict[str, Any]) -> Self:
-        return cls(
-            type=event["type"],
-            object=event["raw_object"],
-            kind=event["raw_object"]["kind"],
-            name=event["raw_object"]["metadata"]["name"],
-            namespace=event["raw_object"]["metadata"].get("namespace"),
-        )
-
-    def __str__(self) -> str:
-        """Printing the raw object makes it extremely long.
-        So don't do that."""
-        rs = (
-            f"KubernetesEvent(type='{self.type}', "
-            + f"object.kind='{self.kind}', "
-            + f"object.metadata.name='{self.name}'"
-        )
-        if self.namespace is not None:
-            rs += f", object.metadata.namespace='{self.namespace}'"
-        rs += ")"
-        return rs
-
-
-@dataclass
-class KubernetesPodWatchInfo:
-    """Packages useful info for setting up a watch for a Pod."""
-
-    watch_args: dict[str, str]
-    initial_phase: str
-
-    @classmethod
-    def from_pod(cls, pod: V1Pod) -> Self:
-        return cls(
-            initial_phase=pod.status.phase,
-            watch_args=get_watch_args(pod.metadata),
-        )
-
-
-@dataclass
-class KubernetesKindMethodContainer:
-    object_type: object
-    read_method: Coroutine[Any, Any, Any]
-    list_method: Coroutine[Any, Any, Any]
-
-
-class KubernetesKindMethodMapper:
-    def __init__(self) -> None:
-        self._dict: dict[str, KubernetesKindMethodContainer] = dict()
-
-    def add(self, key: str, val: KubernetesKindMethodContainer) -> None:
-        self._dict[key] = val
-
-    def get(self, key: str) -> KubernetesKindMethodContainer:
-        return self._dict[key]
-
-    def list(self) -> list[str]:
-        return list(self._dict.keys())
-
-
-def get_watch_args(metadata: V1ObjectMeta) -> dict[str, str]:
-    watch_args = {
-        "field_selector": f"metadata.name={metadata.name}",
-    }
-    if metadata.resource_version is not None:
-        watch_args["resource_version"] = metadata.resource_version
-    if metadata.namespace is not None:
-        watch_args["namespace"] = metadata.namespace
-    return watch_args

--- a/src/jupyterlabcontroller/storage/kubernetes/pod.py
+++ b/src/jupyterlabcontroller/storage/kubernetes/pod.py
@@ -1,0 +1,204 @@
+"""Storage layer for ``Pod`` objects."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import timedelta
+
+from kubernetes_asyncio import client
+from kubernetes_asyncio.client import ApiClient, CoreV1Event, V1Pod
+from structlog.stdlib import BoundLogger
+
+from ...models.domain.kubernetes import KubernetesPodPhase, WatchEventType
+from .deleter import KubernetesObjectDeleter
+from .watcher import KubernetesWatcher
+
+__all__ = ["PodStorage"]
+
+
+class PodStorage(KubernetesObjectDeleter):
+    """Storage layer for ``Pod`` objects.
+
+    Parameters
+    ----------
+    api_client
+        Kubernetes API client.
+    logger
+        Logger to use.
+    """
+
+    def __init__(self, api_client: ApiClient, logger: BoundLogger) -> None:
+        self._api = client.CoreV1Api(api_client)
+        super().__init__(
+            create_method=self._api.create_namespaced_pod,
+            delete_method=self._api.delete_namespaced_pod,
+            list_method=self._api.list_namespaced_pod,
+            read_method=self._api.read_namespaced_pod,
+            object_type=V1Pod,
+            kind="Pod",
+            logger=logger,
+        )
+
+    async def delete_after_completion(
+        self, name: str, namespace: str, *, timeout: timedelta | None = None
+    ) -> None:
+        """Wait for a pod to complete and then delete it.
+
+        This first waits for a pod to finish running, after which it deletes
+        the pod. This method does not wait for the pod to be deleted before
+        returning.
+
+        Parameters
+        ----------
+        name
+            Name of the pod.
+        namespace
+            Namespace of the pod.
+        timeout
+            How long to wait for the pod to start and then stop.  This timeout
+            is not applied to the deletion.
+
+        Raises
+        ------
+        KubernetesError
+            Raised if there is some failure in a Kubernetes API call.
+        """
+        logger = self._logger.bind(name=name, namespace=namespace)
+        phase = await self.wait_for_phase(
+            name,
+            namespace,
+            until_not={
+                KubernetesPodPhase.UNKNOWN,
+                KubernetesPodPhase.PENDING,
+                KubernetesPodPhase.RUNNING,
+            },
+            timeout=timeout,
+        )
+        if phase is None:
+            logger.warning("Pod was already missing")
+            return
+        if phase == KubernetesPodPhase.SUCCEEDED:
+            logger.debug("Removing succeeded pod")
+        else:
+            logger.warning(f"Removing pod in phase {phase.value}")
+        await self.delete(name, namespace)
+
+    async def events_for_pod(
+        self, name: str, namespace: str
+    ) -> AsyncIterator[str]:
+        """Iterate over Kubernetes events involving a pod.
+
+        Watches for events involving a pod, yielding them. Must be cancelled
+        by the caller when the watch is no longer of interest.
+
+        Parameters
+        ----------
+        name
+            Name of the pod.
+        namespace
+            Namespace in which the pod is located.
+
+        Yields
+        ------
+        str
+            The next observed event.
+
+        Raises
+        ------
+        KubernetesError
+            Raised if there is some failure in a Kubernetes API call.
+        """
+        logger = self._logger.bind(pod=name, namespace=namespace)
+        logger.debug("Watching pod events")
+        watcher = KubernetesWatcher(
+            method=self._api.list_namespaced_event,
+            object_type=CoreV1Event,
+            kind="Event",
+            involved_object=name,
+            namespace=namespace,
+            logger=logger,
+        )
+        try:
+            async for event in watcher.watch():
+                yield event.object.message
+        finally:
+            await watcher.close()
+
+        # This should be impossible; someone called stop on the watcher.
+        raise RuntimeError("Wait for pod events unexpectedly stopped")
+
+    async def wait_for_phase(
+        self,
+        name: str,
+        namespace: str,
+        *,
+        until_not: set[KubernetesPodPhase],
+        timeout: timedelta | None = None,
+    ) -> KubernetesPodPhase | None:
+        """Waits for a pod to finish starting.
+
+        Waits for the pod to reach a phase other than the ones given, and
+        returns the new phase.
+
+        Parameters
+        ----------
+        pod_name
+            Name of the pod.
+        namespace
+            Namespace in which the pod is located.
+        until_not
+            Wait until the pod is not in one of these phases (or was deleted,
+            or the watch timed out).
+        timeout
+            Timeout to wait for the pod to start.
+
+        Returns
+        -------
+        KubernetesPodPhase
+            New pod phase, or `None` if the pod has disappeared.
+
+        Raises
+        ------
+        KubernetesError
+            Raised if there is some failure in a Kubernetes API call.
+        """
+        logger = self._logger.bind(name=name, namespace=namespace)
+        logger.debug("Waiting for pod phase change", until_not=list(until_not))
+
+        # Retrieve the object first. It's possible that it's already in the
+        # correct phase, and we can return immediately. If not, we want to
+        # start watching events with the next event after the current object
+        # version. Note that we treat Unknown the same as Pending; we rely on
+        # the timeout and otherwise hope that Kubernetes will figure out the
+        # phase.
+        pod = await self.read(name, namespace)
+        if pod is None:
+            return None
+        phase = KubernetesPodPhase(pod.status.phase)
+        if phase not in until_not:
+            return phase
+
+        # The pod is not in a terminal phase. Start the watch and wait for it
+        # to change state.
+        watcher = KubernetesWatcher(
+            method=self._list,
+            object_type=V1Pod,
+            kind="Pod",
+            name=pod.metadata.name,
+            namespace=pod.metadata.namespace,
+            resource_version=pod.metadata.resource_version,
+            timeout=timeout,
+            logger=logger,
+        )
+        try:
+            async for event in watcher.watch():
+                if event.action == WatchEventType.DELETED:
+                    return None
+                phase = KubernetesPodPhase(event.object.status.phase)
+                if phase not in until_not:
+                    return phase
+        finally:
+            await watcher.close()
+
+        # This should be impossible; someone called stop on the watcher.
+        raise RuntimeError("Wait for pod phase change unexpectedly stopped")

--- a/tests/fileserver/handlers/object_cleanup_on_exit_test.py
+++ b/tests/fileserver/handlers/object_cleanup_on_exit_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 import pytest
@@ -81,6 +82,7 @@ async def test_cleanup_on_pod_exit(
             }
         ],
     )
+    await asyncio.sleep(0.1)
     # Check that the fileserver user map is clear
     r = await client.get("/nublado/fileserver/v1/users")
     assert r.json() == []


### PR DESCRIPTION
Add a new PodStorage class based on KubernetesObjectDeleter. Move a generic function for waiting for pod phases to it, and call that function instead of doing the watch directly in K8sStorageClient. Move the async iterator for pod events into that class as well, and change it to use the new KubernetesWatcher class.

Pods had several features that other types didn't need, so add them to the generic layer: proper timeout tracking on watches in case the server times us out before our timeout was reached, grace period on object deletion, and listing with a label selector.

Use a custom logger for watches from the new storage layer so that any log messages produced by the watch will include the object name and namespace when appropriate. Also fix the KubernetesWatcher object to not destructively modify its arguments so that it's reusable, not that we use that at the moment.

Clean up all of the old generic storage infrastructure from K8sStorageClient, since it's no longer needed.