### PR TITLE
DM-40691: Rename KubernetesPodPhase to PodPhase

### DIFF
--- a/src/jupyterlabcontroller/models/domain/kubernetes.py
+++ b/src/jupyterlabcontroller/models/domain/kubernetes.py
@@ -14,7 +14,7 @@ from .docker import DockerReference
 __all__ = [
     "KubernetesModel",
     "KubernetesNodeImage",
-    "KubernetesPodPhase",
+    "PodPhase",
     "PropagationPolicy",
     "WatchEventType",
 ]
@@ -104,7 +104,7 @@ class KubernetesNodeImage:
         return None
 
 
-class KubernetesPodPhase(str, Enum):
+class PodPhase(str, Enum):
     """One of the valid phases reported in the status section of a Pod."""
 
     PENDING = "Pending"

--- a/src/jupyterlabcontroller/services/state.py
+++ b/src/jupyterlabcontroller/services/state.py
@@ -18,7 +18,7 @@ from structlog.stdlib import BoundLogger
 from ..config import LabConfig
 from ..constants import LAB_STATE_REFRESH_INTERVAL
 from ..exceptions import KubernetesError, LabExistsError, UnknownUserError
-from ..models.domain.kubernetes import KubernetesPodPhase
+from ..models.domain.kubernetes import PodPhase
 from ..models.domain.lab import UserLab
 from ..models.v1.event import Event, EventType
 from ..models.v1.lab import (
@@ -175,7 +175,7 @@ class LabStateManager:
             lab.state.status = LabStatus.FAILED
             lab.state.pod = PodState.MISSING
         elif lab.state.status == LabStatus.RUNNING:
-            if phase != KubernetesPodPhase.RUNNING:
+            if phase != PodPhase.RUNNING:
                 lab.state.status = LabStatus.FAILED
         return lab.state
 

--- a/src/jupyterlabcontroller/storage/k8s.py
+++ b/src/jupyterlabcontroller/storage/k8s.py
@@ -41,7 +41,7 @@ from ..exceptions import (
 )
 from ..models.domain.kubernetes import (
     KubernetesNodeImage,
-    KubernetesPodPhase,
+    PodPhase,
     PropagationPolicy,
 )
 from ..models.v1.lab import ResourceQuantity
@@ -115,7 +115,7 @@ class K8sStorageClient:
 
     async def get_pod_phase(
         self, name: str, namespace: str
-    ) -> KubernetesPodPhase | None:
+    ) -> PodPhase | None:
         """Get the phase of a currently running pod.
 
         Called whenever JupyterHub wants to check the status of running pods,
@@ -130,7 +130,7 @@ class K8sStorageClient:
 
         Returns
         -------
-        KubernetesPodPhase or None
+        PodPhase or None
             Phase of the pod or `None` if the pod does not exist.
 
         Raises
@@ -147,7 +147,7 @@ class K8sStorageClient:
 
     async def wait_for_pod_start(
         self, pod_name: str, namespace: str, timeout: timedelta | None = None
-    ) -> KubernetesPodPhase | None:
+    ) -> PodPhase | None:
         """Waits for a pod to finish starting.
 
         Waits for the pod to reach a phase other than pending or unknown, and
@@ -166,7 +166,7 @@ class K8sStorageClient:
 
         Returns
         -------
-        KubernetesPodPhase
+        PodPhase
             New pod phase, or `None` if the pod has disappeared.
 
         Raises
@@ -177,13 +177,13 @@ class K8sStorageClient:
         return await self._pod.wait_for_phase(
             pod_name,
             namespace,
-            until_not={KubernetesPodPhase.UNKNOWN, KubernetesPodPhase.PENDING},
+            until_not={PodPhase.UNKNOWN, PodPhase.PENDING},
             timeout=timeout or self._spawn_timeout,
         )
 
     async def wait_for_pod_stop(
         self, pod_name: str, namespace: str
-    ) -> KubernetesPodPhase | None:
+    ) -> PodPhase | None:
         """Waits for a pod to terminate.
 
         Waits for the pod to reach a phase other than running or unknown, and
@@ -199,7 +199,7 @@ class K8sStorageClient:
 
         Returns
         -------
-        KubernetesPodPhase
+        PodPhase
             New pod phase, or `None` if the pod has disappeared.
 
         Raises
@@ -210,7 +210,7 @@ class K8sStorageClient:
         return await self._pod.wait_for_phase(
             pod_name,
             namespace,
-            until_not={KubernetesPodPhase.UNKNOWN, KubernetesPodPhase.RUNNING},
+            until_not={PodPhase.UNKNOWN, PodPhase.RUNNING},
             timeout=self._spawn_timeout,
         )
 

--- a/tests/fileserver/handlers/object_cleanup_on_exit_test.py
+++ b/tests/fileserver/handlers/object_cleanup_on_exit_test.py
@@ -11,7 +11,7 @@ from kubernetes_asyncio.client import V1Pod
 from safir.testing.kubernetes import MockKubernetesApi
 
 from jupyterlabcontroller.config import Config
-from jupyterlabcontroller.models.domain.kubernetes import KubernetesPodPhase
+from jupyterlabcontroller.models.domain.kubernetes import PodPhase
 
 from ...settings import TestObjectFactory
 from ...support.docker import MockDockerRegistry
@@ -78,7 +78,7 @@ async def test_cleanup_on_pod_exit(
             {
                 "op": "replace",
                 "path": "/status/phase",
-                "value": KubernetesPodPhase.SUCCEEDED.value,
+                "value": PodPhase.SUCCEEDED.value,
             }
         ],
     )

--- a/tests/handlers/labs_test.py
+++ b/tests/handlers/labs_test.py
@@ -23,7 +23,7 @@ from safir.testing.slack import MockSlackWebhook
 from jupyterlabcontroller.config import Config
 from jupyterlabcontroller.constants import DROPDOWN_SENTINEL_VALUE
 from jupyterlabcontroller.factory import Factory
-from jupyterlabcontroller.models.domain.kubernetes import KubernetesPodPhase
+from jupyterlabcontroller.models.domain.kubernetes import PodPhase
 
 from ..settings import TestObjectFactory
 from ..support.constants import TEST_BASE_URL
@@ -186,7 +186,7 @@ async def test_lab_start_stop(
     name = f"{user.username}-nb"
     namespace = f"userlabs-{user.username}"
     pod = await mock_kubernetes.read_namespaced_pod(name, namespace)
-    pod.status.phase = KubernetesPodPhase.FAILED.value
+    pod.status.phase = PodPhase.FAILED.value
     r = await client.get(f"/nublado/spawner/v1/labs/{user.username}")
     assert r.status_code == 200
     expected["status"] = "failed"
@@ -246,7 +246,7 @@ async def test_spawn_after_failure(
             {
                 "op": "replace",
                 "path": "/status/phase",
-                "value": KubernetesPodPhase.FAILED.value,
+                "value": PodPhase.FAILED.value,
             }
         ],
     )
@@ -269,7 +269,7 @@ async def test_spawn_after_failure(
         f"{TEST_BASE_URL}/nublado/spawner/v1/labs/{user.username}"
     )
     pod = await mock_kubernetes.read_namespaced_pod(name, namespace)
-    assert pod.status.phase == KubernetesPodPhase.RUNNING.value
+    assert pod.status.phase == PodPhase.RUNNING.value
 
     # Get the events and look for the lab recreation events.
     expected_events = read_output_data("standard", "lab-recreate-events.json")
@@ -286,7 +286,7 @@ async def test_delayed_spawn(
 ) -> None:
     token, user = obj_factory.get_user()
     lab = obj_factory.labspecs[0]
-    mock_kubernetes.initial_pod_phase = KubernetesPodPhase.PENDING.value
+    mock_kubernetes.initial_pod_phase = PodPhase.PENDING.value
 
     r = await client.post(
         f"/nublado/spawner/v1/labs/{user.username}/create",
@@ -341,7 +341,7 @@ async def test_delayed_spawn(
             {
                 "op": "replace",
                 "path": "/status/phase",
-                "value": KubernetesPodPhase.RUNNING.value,
+                "value": PodPhase.RUNNING.value,
             }
         ],
     )

--- a/tests/handlers/user_status_test.py
+++ b/tests/handlers/user_status_test.py
@@ -7,7 +7,7 @@ from httpx import AsyncClient
 from safir.testing.kubernetes import MockKubernetesApi
 
 from jupyterlabcontroller.factory import Factory
-from jupyterlabcontroller.models.domain.kubernetes import KubernetesPodPhase
+from jupyterlabcontroller.models.domain.kubernetes import PodPhase
 
 from ..settings import TestObjectFactory
 from ..support.constants import TEST_BASE_URL
@@ -90,7 +90,7 @@ async def test_user_status(
     name = f"{user.username}-nb"
     namespace = f"userlabs-{user.username}"
     pod = await mock_kubernetes.read_namespaced_pod(name, namespace)
-    pod.status.phase = KubernetesPodPhase.FAILED.value
+    pod.status.phase = PodPhase.FAILED.value
     r = await client.get(
         "/nublado/spawner/v1/user-status",
         headers={"X-Auth-Request-User": user.username},

--- a/tests/services/prepuller_test.py
+++ b/tests/services/prepuller_test.py
@@ -24,7 +24,7 @@ from safir.testing.slack import MockSlackWebhook
 
 from jupyterlabcontroller.config import Config
 from jupyterlabcontroller.factory import Factory
-from jupyterlabcontroller.models.domain.kubernetes import KubernetesPodPhase
+from jupyterlabcontroller.models.domain.kubernetes import PodPhase
 from jupyterlabcontroller.models.v1.prepuller_config import GARSourceConfig
 
 from ..settings import TestObjectFactory
@@ -57,7 +57,7 @@ async def mark_pod_complete(
             {
                 "op": "replace",
                 "path": "/status/phase",
-                "value": KubernetesPodPhase.SUCCEEDED.value,
+                "value": PodPhase.SUCCEEDED.value,
             }
         ],
     )

--- a/tests/services/state_test.py
+++ b/tests/services/state_test.py
@@ -17,7 +17,7 @@ from jupyterlabcontroller.config import Config
 from jupyterlabcontroller.factory import Factory
 from jupyterlabcontroller.models.domain.docker import DockerReference
 from jupyterlabcontroller.models.domain.gafaelfawr import GafaelfawrUser
-from jupyterlabcontroller.models.domain.kubernetes import KubernetesPodPhase
+from jupyterlabcontroller.models.domain.kubernetes import PodPhase
 from jupyterlabcontroller.models.v1.lab import (
     LabStatus,
     PodState,
@@ -142,7 +142,7 @@ async def test_reconcile_pending(
     obj_factory: TestObjectFactory,
     mock_kubernetes: MockKubernetesApi,
 ) -> None:
-    mock_kubernetes.initial_pod_phase = KubernetesPodPhase.PENDING.value
+    mock_kubernetes.initial_pod_phase = PodPhase.PENDING.value
     expected = await create_lab(config, factory, obj_factory, mock_kubernetes)
     _, user = obj_factory.get_user()
 
@@ -167,7 +167,7 @@ async def test_reconcile_pending(
             {
                 "op": "replace",
                 "path": "/status/phase",
-                "value": KubernetesPodPhase.RUNNING.value,
+                "value": PodPhase.RUNNING.value,
             }
         ],
     )
@@ -191,7 +191,7 @@ async def test_spawn_timeout(
         await mock_kubernetes.create_namespaced_secret(
             config.lab.namespace_prefix, secret
         )
-    mock_kubernetes.initial_pod_phase = KubernetesPodPhase.PENDING.value
+    mock_kubernetes.initial_pod_phase = PodPhase.PENDING.value
     config.lab.spawn_timeout = timedelta(seconds=1)
     token, user = obj_factory.get_user()
     user = GafaelfawrUser(token=token, **user.dict())


### PR DESCRIPTION
This is the only type of pod that we could be talking about, so the new name is not ambiguous, and we use this in various places where saving some characters means nicer formatting.