### PR TITLE
DM-40809: Converted to Ruff for linting and fixed most resulting errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,22 +2,25 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
-      - id: trailing-whitespace
+      - id: check-merge-conflict
       - id: check-yaml
       - id: check-toml
+      - id: trailing-whitespace
 
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.0.289
     hooks:
-      - id: isort
-        additional_dependencies: [toml]
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
 
   - repo: https://github.com/psf/black
     rev: 23.9.1
     hooks:
       - id: black
 
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
+  - repo: https://github.com/adamchainz/blacken-docs
+    rev: 1.16.0
     hooks:
-      - id: flake8
+      - id: blacken-docs
+        additional_dependencies: [black==23.9.1]
+        args: [-l, '79', -t, py311]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,7 @@ ignore = [
     "PLR2004", # too aggressive about magic values
     "S105",    # good idea but too many false positives on non-passwords
     "S106",    # good idea but too many false positives on non-passwords
+    "S107",    # good idea but too many false positives on non-passwords
     "S603",    # not going to manually mark every subprocess call as reviewed
     "S607",    # using PATH is not a security vulnerability
     "SIM102",  # sometimes the formatting of nested if statements is clearer
@@ -168,10 +169,14 @@ target-version = "py311"
 "src/jupyterlabcontroller/handlers/**" = [
     "D103",    # FastAPI handlers should not have docstrings
 ]
+"src/jupyterlabcontroller/services/**" = [
+    "S108",    # constructing /tmp paths for Kubernetes Pods
+]
 "tests/**" = [
     "C901",    # tests are allowed to be complex, sometimes that's convenient
     "D101",    # tests don't need docstrings
     "D103",    # tests don't need docstrings
+    "PLR0124", # these tests are required to test ordering dunder methods
     "PLR0915", # tests are allowed to be long, sometimes that's convenient
     "PT012",   # way too aggressive about limiting pytest.raises blocks
     "S101",    # tests should use assert
@@ -202,7 +207,9 @@ builtins-ignorelist = [
     "help",
     "id",
     "list",
+    "object",
     "open",
+    "set",
     "type",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,24 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 
+[tool.black]
+line-length = 79
+target-version = ["py311"]
+exclude = '''
+/(
+    \.eggs
+  | \.git
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | build
+  | dist
+)/
+'''
+# Use single-quoted strings so TOML treats the string like a Python r-string
+# Multi-line strings are implicitly treated by black as regular expressions
+
 [tool.coverage.run]
 parallel = true
 branch = true
@@ -56,47 +74,6 @@ exclude_lines = [
     "if TYPE_CHECKING:",
 ]
 
-[tool.black]
-line-length = 79
-target-version = ["py311"]
-exclude = '''
-/(
-    \.eggs
-  | \.git
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | _build
-  | build
-  | dist
-)/
-'''
-# Use single-quoted strings so TOML treats the string like a Python r-string
-# Multi-line strings are implicitly treated by black as regular expressions
-
-[tool.isort]
-profile = "black"
-line_length = 79
-known_first_party = ["jupyterlabcontroller", "tests"]
-skip = ["docs/conf.py"]
-
-[tool.pytest.ini_options]
-asyncio_mode = "strict"
-filterwarnings = [
-    # Google modules call a deprecated pkg_resources API.
-    "ignore:pkg_resources is deprecated as an API:DeprecationWarning",
-    "ignore:.*pkg_resources\\.declare_namespace:DeprecationWarning",
-]
-# The python_files setting is not for test detection (pytest will pick up any
-# test files named *_test.py without this setting) but to enable special
-# assert processing in any non-test supporting files under tests.  We
-# conventionally put test support functions under tests.support and may
-# sometimes use assert in test fixtures in conftest.py, and pytest only
-# enables magical assert processing (showing a full diff on assert failures
-# with complex data structures rather than only the assert message) in files
-# listed in python_files.
-python_files = ["tests/*.py", "tests/*/*.py"]
-
 [tool.mypy]
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
@@ -115,3 +92,123 @@ init_forbid_extra = true
 init_typed = true
 warn_required_dynamic_aliases = true
 warn_untyped_fields = true
+
+[tool.pytest.ini_options]
+asyncio_mode = "strict"
+filterwarnings = [
+    # Google modules call a deprecated pkg_resources API.
+    "ignore:pkg_resources is deprecated as an API:DeprecationWarning",
+    "ignore:.*pkg_resources\\.declare_namespace:DeprecationWarning",
+]
+# The python_files setting is not for test detection (pytest will pick up any
+# test files named *_test.py without this setting) but to enable special
+# assert processing in any non-test supporting files under tests.  We
+# conventionally put test support functions under tests.support and may
+# sometimes use assert in test fixtures in conftest.py, and pytest only
+# enables magical assert processing (showing a full diff on assert failures
+# with complex data structures rather than only the assert message) in files
+# listed in python_files.
+python_files = [
+    "tests/*.py",
+    "tests/*/*.py",
+]
+
+# The rule used with Ruff configuration is to disable every lint that has
+# legitimate exceptions that are not dodgy code, rather than cluttering code
+# with noqa markers. This is therefore a reiatively relaxed configuration that
+# errs on the side of disabling legitimate lints.
+#
+# Reference for settings: https://beta.ruff.rs/docs/settings/
+# Reference for rules: https://beta.ruff.rs/docs/rules/
+[tool.ruff]
+exclude = [
+    "docs/**",
+]
+line-length = 79
+ignore = [
+    "ANN101",  # self should not have a type annotation
+    "ANN102",  # cls should not have a type annotation
+    "ANN401",  # sometimes Any is the right type
+    "ARG001",  # unused function arguments are often legitimate
+    "ARG002",  # unused method arguments are often legitimate
+    "ARG005",  # unused lambda arguments are often legitimate
+    "BLE001",  # we want to catch and report Exception in background tasks
+    "C414",    # nested sorted is how you sort by multiple keys with reverse
+    "COM812",  # omitting trailing commas allows black autoreformatting
+    "D102",    # sometimes we use docstring inheritence
+    "D104",    # don't see the point of documenting every package
+    "D105",    # our style doesn't require docstrings for magic methods
+    "D106",    # Pydantic uses a nested Config class that doesn't warrant docs
+    "D205",    # our documentation style allows a folded first line
+    "EM101",   # justification (duplicate string in traceback) is silly
+    "EM102",   # justification (duplicate string in traceback) is silly
+    "FBT003",  # positional booleans are normal for Pydantic field defaults
+    "FIX002",  # point of a TODO comment is that we're not ready to fix it
+    "G004",    # forbidding logging f-strings is appealing, but not our style
+    "RET505",  # disagree that omitting else always makes code more readable
+    "PLR0913", # factory pattern uses constructors with many arguments
+    "PLR2004", # too aggressive about magic values
+    "S105",    # good idea but too many false positives on non-passwords
+    "S106",    # good idea but too many false positives on non-passwords
+    "S603",    # not going to manually mark every subprocess call as reviewed
+    "S607",    # using PATH is not a security vulnerability
+    "SIM102",  # sometimes the formatting of nested if statements is clearer
+    "SIM117",  # sometimes nested with contexts are clearer
+    "TCH001",  # we decided to not maintain separate TYPE_CHECKING blocks
+    "TCH002",  # we decided to not maintain separate TYPE_CHECKING blocks
+    "TCH003",  # we decided to not maintain separate TYPE_CHECKING blocks
+    "TD003",   # we don't require issues be created for TODOs
+    "TID252",  # if we're going to use relative imports, use them always
+    "TRY003",  # good general advice but lint is way too aggressive
+]
+select = ["ALL"]
+target-version = "py311"
+
+[tool.ruff.per-file-ignores]
+"src/jupyterlabcontroller/handlers/**" = [
+    "D103",    # FastAPI handlers should not have docstrings
+]
+"tests/**" = [
+    "C901",    # tests are allowed to be complex, sometimes that's convenient
+    "D101",    # tests don't need docstrings
+    "D103",    # tests don't need docstrings
+    "PLR0915", # tests are allowed to be long, sometimes that's convenient
+    "PT012",   # way too aggressive about limiting pytest.raises blocks
+    "S101",    # tests should use assert
+    "S106",    # tests are allowed to hard-code dummy passwords
+    "SLF001",  # tests are allowed to access private members
+]
+
+[tool.ruff.isort]
+known-first-party = ["jupyterlabcontroller", "tests"]
+split-on-trailing-comma = false
+
+[tool.ruff.flake8-bugbear]
+extend-immutable-calls = [
+    "fastapi.Form",
+    "fastapi.Header",
+    "fastapi.Depends",
+    "fastapi.Path",
+    "fastapi.Query",
+]
+
+# These are too useful as attributes or methods to allow the conflict with the
+# built-in to rule out their use.
+[tool.ruff.flake8-builtins]
+builtins-ignorelist = [
+    "all",
+    "any",
+    "dict",
+    "help",
+    "id",
+    "list",
+    "open",
+    "type",
+]
+
+[tool.ruff.flake8-pytest-style]
+fixture-parentheses = false
+mark-parentheses = false
+
+[tool.ruff.pydocstyle]
+convention = "numpy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ ignore = [
     "FIX002",  # point of a TODO comment is that we're not ready to fix it
     "G004",    # forbidding logging f-strings is appealing, but not our style
     "RET505",  # disagree that omitting else always makes code more readable
+    "PLR0911", # often many returns is clearer and simpler style
     "PLR0913", # factory pattern uses constructors with many arguments
     "PLR2004", # too aggressive about magic values
     "S105",    # good idea but too many false positives on non-passwords

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,16 @@ ignore = [
     "TD003",   # we don't require issues be created for TODOs
     "TID252",  # if we're going to use relative imports, use them always
     "TRY003",  # good general advice but lint is way too aggressive
+
+    # TEMPORARY exclusions while refactoring is in progress. All of these will
+    # be re-enabled once refactoring is complete.
+    "C901",
+    "D100",
+    "D101",
+    "D103",
+    "D401",
+    "D404",
+    "PLR0912",
 ]
 select = ["ALL"]
 target-version = "py311"

--- a/src/jupyterlabcontroller/config.py
+++ b/src/jupyterlabcontroller/config.py
@@ -6,7 +6,7 @@ import os
 from datetime import timedelta
 from enum import Enum
 from pathlib import Path
-from typing import Literal, Optional, Self
+from typing import Literal, Self
 
 import yaml
 from pydantic import Field, field_validator, model_validator
@@ -244,12 +244,12 @@ class LabSecret(CamelCaseModel):
         ),
         examples=["butler-credentials"],
     )
-    env: Optional[str] = Field(
+    env: str | None = Field(
         None,
         title="Environment variable to set to secret value",
         examples=["BUTLER_CREDENTIALS"],
     )
-    path: Optional[str] = Field(
+    path: str | None = Field(
         None,
         title="Path inside lab at which to mount secret",
         examples=["/opt/lsst/software/jupyterlab/butler-secret"],
@@ -293,7 +293,7 @@ class LabConfig(CamelCaseModel):
     init_containers: list[LabInitContainer] = Field(
         [], title="Initialization containers to run before user's lab starts"
     )
-    pull_secret: Optional[str] = Field(
+    pull_secret: str | None = Field(
         None,
         title="Pull secret to use for lab pods",
         description=(
@@ -374,7 +374,7 @@ class FileserverConfig(CamelCaseModel):
     path_prefix: str = Field(
         "", title="Fileserver prefix path, to which '/files' is appended"
     )
-    resources: Optional[LabResources] = Field(
+    resources: LabResources | None = Field(
         None, title="Resource requests and limits"
     )
     creation_timeout: int = Field(
@@ -426,7 +426,7 @@ class Config(BaseSettings):
             " pods spawned by the prepuller."
         ),
     )
-    slack_webhook: Optional[str] = Field(
+    slack_webhook: str | None = Field(
         None,
         title="Slack webhook to which to post alerts",
         validation_alias="NUBLADO_SLACK_WEBHOOK",

--- a/src/jupyterlabcontroller/dependencies/config.py
+++ b/src/jupyterlabcontroller/dependencies/config.py
@@ -1,7 +1,6 @@
 """Config dependency."""
 
 from pathlib import Path
-from typing import Optional
 
 from ..config import Config
 from ..constants import CONFIGURATION_PATH
@@ -10,7 +9,7 @@ from ..constants import CONFIGURATION_PATH
 class ConfigDependency:
     def __init__(self, path: Path = CONFIGURATION_PATH) -> None:
         self._path = path
-        self._config: Optional[Config] = None
+        self._config: Config | None = None
 
     async def __call__(self) -> Config:
         return self.config

--- a/src/jupyterlabcontroller/dependencies/context.py
+++ b/src/jupyterlabcontroller/dependencies/context.py
@@ -6,7 +6,7 @@ loaded before it can be instantiated.
 """
 
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any
 
 from fastapi import Depends, Request
 from safir.dependencies.logger import logger_dependency
@@ -69,7 +69,7 @@ class ContextDependency:
     """
 
     def __init__(self) -> None:
-        self._process_context: Optional[ProcessContext] = None
+        self._process_context: ProcessContext | None = None
 
     async def __call__(
         self,

--- a/src/jupyterlabcontroller/exceptions.py
+++ b/src/jupyterlabcontroller/exceptions.py
@@ -510,11 +510,10 @@ class MissingObjectError(SlackException):
                 obj = f"{self.kind} {self.namespace}/{self.name}"
             else:
                 obj = f"{self.kind} {self.name}"
+        elif self.namespace:
+            obj = f"{self.kind} (namespace: {self.namespace})"
         else:
-            if self.namespace:
-                obj = f"{self.kind} (namespace: {self.namespace})"
-            else:
-                obj = self.kind
+            obj = self.kind
         message.blocks.append(SlackTextBlock(heading="Object", text=obj))
         return message
 

--- a/src/jupyterlabcontroller/factory.py
+++ b/src/jupyterlabcontroller/factory.py
@@ -117,7 +117,7 @@ class ProcessContext:
                 config=config.images.source, gar=gar_client, logger=logger
             )
         else:
-            raise RuntimeError("Unknown prepuller configuration type")
+            raise TypeError("Unknown prepuller configuration type")
 
         image_service = ImageService(
             config=config.images,

--- a/src/jupyterlabcontroller/handlers/fileserver.py
+++ b/src/jupyterlabcontroller/handlers/fileserver.py
@@ -19,16 +19,16 @@ __all__ = ["router", "user_router"]
 
 # This router does not go under the safir path prefix, but under its own,
 # which by default is "" -- that is, user files are typically accessed as
-# "{{ base_url }}/files"
-
+# <base-url>/files
+#
 # Note that we don't care what's after /files.
-
+#
 # That's because the requesting user is identified by the header,
 # and if there is already a more specific ingress path, then that
 # ingress will handle the request and we will never see it.  That will be
 # the case if the user already has a running fileserver, since
 # /files/<username> will already be a (basic-auth) ingress for WebDAV.
-
+#
 # So either the user went to just "/files", in which case we figure
 # out whether they need an ingress, and create it (and the backing
 # fileserver) if so, or they went to "/files/<themselves>" but there
@@ -37,11 +37,11 @@ __all__ = ["router", "user_router"]
 # <someone-else>.  In the last case, we do exactly the same thing as
 # for "/files": determine whether they themselves have a fileserver'
 # and create it if it doesn't exist.
-
+#
 # In all these cases, we provide documentation of how to use the created
 # fileserver.  This should eventually move into SquareOne and be nicely
 # styled.
-
+#
 # Finally, if they go to "/files/<someone-else>" and there already
 # is an ingress (that is, someone-else already has a running fileserver)
 # then the user request will go there (and we will never see the request).

--- a/src/jupyterlabcontroller/handlers/labs.py
+++ b/src/jupyterlabcontroller/handlers/labs.py
@@ -136,7 +136,7 @@ async def get_lab_events(
     x_auth_request_user: str = Header(..., include_in_schema=False),
     context: RequestContext = Depends(context_dependency),
 ) -> EventSourceResponse:
-    """Returns the events for the lab of the given user"""
+    """Returns the events for the lab of the given user."""
     if username != x_auth_request_user:
         raise PermissionDeniedError("Permission denied")
     context.rebind_logger(user=username)

--- a/src/jupyterlabcontroller/handlers/labs.py
+++ b/src/jupyterlabcontroller/handlers/labs.py
@@ -108,14 +108,14 @@ async def delete_user_lab(
         e.location = ErrorLocation.path
         e.field_path = ["username"]
         raise
-    except Exception:
+    except Exception as e:
         # The exception was already reported to Slack at the service layer, so
         # convert it to a standard error message instead of letting it
         # propagate as an uncaught exception.
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=[{"msg": "Failed to delete lab", "type": "delete_failed"}],
-        )
+        ) from e
 
 
 @router.get(

--- a/src/jupyterlabcontroller/models/domain/fileserver.py
+++ b/src/jupyterlabcontroller/models/domain/fileserver.py
@@ -1,8 +1,17 @@
-"""Models for the fileserver state.  Async because eventually this is going
-to use Redis.  Locking will be managed external to the user map."""
+"""Models for the fileserver state."""
+
+import contextlib
+
+__all__ = ["FileserverUserMap"]
 
 
 class FileserverUserMap:
+    """File server state.
+
+    All methods are async because eventually this is going to use
+    Redis. Locking will be managed external to the user map.
+    """
+
     def __init__(self) -> None:
         self._dict: dict[str, bool] = {}
 
@@ -16,7 +25,5 @@ class FileserverUserMap:
         self._dict[key] = True
 
     async def remove(self, key: str) -> None:
-        try:
+        with contextlib.suppress(KeyError):
             del self._dict[key]
-        except KeyError:
-            pass

--- a/src/jupyterlabcontroller/models/domain/lab.py
+++ b/src/jupyterlabcontroller/models/domain/lab.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field
-from typing import Optional
 
 from kubernetes_asyncio.client.models import V1Volume, V1VolumeMount
 from safir.asyncio import AsyncMultiQueue
@@ -34,7 +33,7 @@ class UserLab:
     events: AsyncMultiQueue[Event] = field(default_factory=AsyncMultiQueue)
     """Events from the current or most recent lab operation."""
 
-    task: Optional[asyncio.Task[None]] = None
+    task: asyncio.Task[None] | None = None
     """Background task monitoring the progress of a lab operation.
 
     These tasks are not wrapped in an `aiojobs.Spawner` because the

--- a/src/jupyterlabcontroller/models/domain/rspimage.py
+++ b/src/jupyterlabcontroller/models/domain/rspimage.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Iterable, Iterator
 from dataclasses import asdict, dataclass, field
-from typing import Optional, Self
+from typing import Self
 
 from .rsptag import RSPImageTag, RSPImageType
 
@@ -38,7 +38,7 @@ class RSPImage(RSPImageTag):
     digest: str
     """Image digest for the image, including prefixes like ``sha256:``."""
 
-    size: Optional[int] = None
+    size: int | None = None
     """Size of the image in bytes if known."""
 
     aliases: set[str] = field(default_factory=set)
@@ -51,7 +51,7 @@ class RSPImage(RSPImageTag):
     logic that is aware of the contents of the collection.
     """
 
-    alias_target: Optional[str] = None
+    alias_target: str | None = None
     """The tag of the image for which this is an alias, if known."""
 
     nodes: set[str] = field(default_factory=set)
@@ -168,7 +168,7 @@ class RSPImageCollection:
     """
 
     def __init__(
-        self, images: Iterable[RSPImage], cycle: Optional[int] = None
+        self, images: Iterable[RSPImage], cycle: int | None = None
     ) -> None:
         self._by_digest: dict[str, RSPImage]
         self._by_tag_name: dict[str, RSPImage]
@@ -291,7 +291,7 @@ class RSPImageCollection:
         return images[0] if images else None
 
     def mark_image_seen_on_node(
-        self, digest: str, node: str, image_size: Optional[int] = None
+        self, digest: str, node: str, image_size: int | None = None
     ) -> None:
         """Mark an image as seen on a node.
 
@@ -327,7 +327,7 @@ class RSPImageCollection:
         releases: int = 0,
         weeklies: int = 0,
         dailies: int = 0,
-        include: Optional[set[str]] = None,
+        include: set[str] | None = None,
     ) -> RSPImageCollection:
         """Return a subset of the image collection.
 
@@ -418,7 +418,7 @@ class RSPImageCollection:
         return False
 
     def _replace_contents(
-        self, images: Iterable[RSPImage], cycle: Optional[int] = None
+        self, images: Iterable[RSPImage], cycle: int | None = None
     ) -> None:
         """Replace the contents of the collection with the provided images.
 

--- a/src/jupyterlabcontroller/models/domain/rspimage.py
+++ b/src/jupyterlabcontroller/models/domain/rspimage.py
@@ -215,7 +215,10 @@ class RSPImageCollection:
         self._by_type[image.image_type].sort(reverse=True)
 
     def all_images(
-        self, hide_aliased: bool = False, hide_resolved_aliases: bool = False
+        self,
+        *,
+        hide_aliased: bool = False,
+        hide_resolved_aliases: bool = False,
     ) -> Iterator[RSPImage]:
         """All images in sorted order.
 
@@ -359,9 +362,13 @@ class RSPImageCollection:
 
         # Include additional images if they're present in the collection.
         if include:
-            for tag in include:
-                if tag in self._by_tag_name:
-                    images.append(self._by_tag_name[tag])
+            images.extend(
+                [
+                    self._by_tag_name[t]
+                    for t in include
+                    if t in self._by_tag_name
+                ]
+            )
 
         # Return the results.
         return RSPImageCollection(images)

--- a/src/jupyterlabcontroller/models/domain/rsptag.py
+++ b/src/jupyterlabcontroller/models/domain/rsptag.py
@@ -8,7 +8,7 @@ from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from enum import Enum
 from functools import total_ordering
-from typing import Optional, Self
+from typing import Self
 
 from semver.version import VersionInfo
 
@@ -407,7 +407,7 @@ class RSPImageTagCollection:
         cls,
         tag_names: list[str],
         aliases: set[str],
-        cycle: Optional[int] = None,
+        cycle: int | None = None,
     ) -> Self:
         """Create a collection from tag strings.
 
@@ -453,8 +453,7 @@ class RSPImageTagCollection:
             Each tag in sorted order.
         """
         for image_type in RSPImageType:
-            for tag in self._by_type[image_type]:
-                yield tag
+            yield from self._by_type[image_type]
 
     def tag_for_tag_name(self, tag_name: str) -> RSPImageTag | None:
         """Look up a tag by tag name.
@@ -477,7 +476,7 @@ class RSPImageTagCollection:
         releases: int = 0,
         weeklies: int = 0,
         dailies: int = 0,
-        include: Optional[set[str]] = None,
+        include: set[str] | None = None,
     ) -> RSPImageTagCollection:
         """Return a subset of the tag collection.
 

--- a/src/jupyterlabcontroller/models/v1/event.py
+++ b/src/jupyterlabcontroller/models/v1/event.py
@@ -2,7 +2,6 @@
 
 import json
 from enum import Enum
-from typing import Optional
 
 from pydantic import BaseModel, Field
 from sse_starlette import ServerSentEvent
@@ -25,7 +24,7 @@ class Event(BaseModel):
 
     type: EventType = Field(..., title="Type of the event")
     message: str = Field(..., title="Event message")
-    progress: Optional[int] = Field(
+    progress: int | None = Field(
         None, title="Progress percentage", le=100, gt=0
     )
 

--- a/src/jupyterlabcontroller/models/v1/lab.py
+++ b/src/jupyterlabcontroller/models/v1/lab.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any, Self
 
+from kubernetes_asyncio.client import V1ResourceRequirements
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from ...constants import DROPDOWN_SENTINEL_VALUE, USERNAME_REGEX
@@ -364,7 +365,7 @@ class ResourceQuantity(BaseModel):
         description=(
             "cf. "
             "https://kubernetes.io/docs/tasks/"
-            "configure-pod-container/assign-cpu-resource/\n"
+            "configure-pod-container/assign-cpu-resource/"
         ),
     )
     memory: int = Field(
@@ -379,6 +380,19 @@ class LabResources(BaseModel):
     requests: ResourceQuantity = Field(
         ..., title="Intially-requested resources"
     )
+
+    def to_kubernetes(self) -> V1ResourceRequirements:
+        """Convert to the Kubernetes object representation."""
+        return V1ResourceRequirements(
+            limits={
+                "cpu": str(self.limits.cpu),
+                "memory": str(self.limits.memory),
+            },
+            requests={
+                "cpu": str(self.requests.cpu),
+                "memory": str(self.requests.memory),
+            },
+        )
 
 
 class UserLabState(LabSpecification):

--- a/src/jupyterlabcontroller/models/v1/lab.py
+++ b/src/jupyterlabcontroller/models/v1/lab.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Optional, Self
+from typing import Any, Self
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -118,13 +118,13 @@ class UserOptions(BaseModel):
     without modifications.
     """
 
-    image_list: Optional[str] = Field(
+    image_list: str | None = Field(
         None,
         examples=["lighthouse.ceres/library/sketchbook:w_2023_07@sha256:abcd"],
         title="Image from selection radio button",
         description="If this is set, `image_dropdown` should not be set.",
     )
-    image_dropdown: Optional[str] = Field(
+    image_dropdown: str | None = Field(
         None,
         examples=["lighthouse.ceres/library/sketchbook:w_2022_40"],
         title="Image from dropdown list",
@@ -133,7 +133,7 @@ class UserOptions(BaseModel):
             f" `{DROPDOWN_SENTINEL_VALUE}`."
         ),
     )
-    image_class: Optional[ImageClass] = Field(
+    image_class: ImageClass | None = Field(
         None,
         examples=[ImageClass.RECOMMENDED],
         title="Class of image to spawn",
@@ -145,7 +145,7 @@ class UserOptions(BaseModel):
             " using these options."
         ),
     )
-    image_tag: Optional[str] = Field(
+    image_tag: str | None = Field(
         None,
         examples=["w_2023_07"],
         title="Tag of image to spawn",
@@ -389,7 +389,7 @@ class UserLabState(LabSpecification):
         ..., examples=["running"], title="Status of user container"
     )
     pod: PodState = Field(..., examples=["present"], title="User pod state")
-    internal_url: Optional[str] = Field(
+    internal_url: str | None = Field(
         None,
         examples=["http://nublado-ribbon.nb-ribbon:8888"],
         title="URL by which the Hub can access the user Pod",

--- a/src/jupyterlabcontroller/models/v1/lab.py
+++ b/src/jupyterlabcontroller/models/v1/lab.py
@@ -241,7 +241,7 @@ class UserOptions(BaseModel):
         # Check that exactly one of them is set.
         if len(values_set) < 1:
             raise ValueError("No image to spawn specified")
-        elif len(values_set) > 1:
+        if len(values_set) > 1:
             keys = ", ".join(sorted(values_set))
             raise ValueError(f"Image specified multiple ways ({keys})")
         return self

--- a/src/jupyterlabcontroller/models/v1/prepuller.py
+++ b/src/jupyterlabcontroller/models/v1/prepuller.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Optional, Self
+from typing import Self
 
 from pydantic import BaseModel, Field
 
@@ -23,7 +23,7 @@ class Image(BaseModel):
         examples=["Latest Daily (Daily 2077_10_23)"],
         title="Human-readable version of image tag",
     )
-    digest: Optional[str] = Field(
+    digest: str | None = Field(
         None,
         examples=[
             (
@@ -77,26 +77,20 @@ class PrepulledImage(Image):
 
 
 class NodeImage(Image):
-    size: Optional[int] = Field(
+    size: int | None = Field(
         None, examples=[8675309], title="Size in bytes of image if known"
     )
     nodes: list[str] = Field([], title="Nodes on which image is cached")
-    missing: Optional[list[str]] = Field(
+    missing: list[str] | None = Field(
         None, title="Nodes not caching the image"
     )
 
 
 class SpawnerImages(BaseModel):
-    recommended: Optional[PrepulledImage] = Field(
-        None, title="Recommended image"
-    )
-    latest_weekly: Optional[PrepulledImage] = Field(
-        None, title="Latest weekly"
-    )
-    latest_daily: Optional[PrepulledImage] = Field(None, title="Latest daily")
-    latest_release: Optional[PrepulledImage] = Field(
-        None, title="Latest release"
-    )
+    recommended: PrepulledImage | None = Field(None, title="Recommended image")
+    latest_weekly: PrepulledImage | None = Field(None, title="Latest weekly")
+    latest_daily: PrepulledImage | None = Field(None, title="Latest daily")
+    latest_release: PrepulledImage | None = Field(None, title="Latest release")
     all: list[PrepulledImage] = Field(..., title="All available images")
 
 
@@ -117,7 +111,7 @@ class Node(BaseModel):
     eligible: bool = Field(
         True, examples=[True], title="Whether node is eligible for prepulling"
     )
-    comment: Optional[str] = Field(
+    comment: str | None = Field(
         None,
         examples=["Cordoned because of disk problems"],
         title="Reason for node ineligibility",

--- a/src/jupyterlabcontroller/models/v1/prepuller_config.py
+++ b/src/jupyterlabcontroller/models/v1/prepuller_config.py
@@ -7,7 +7,7 @@ so it has to live in its own file separate from the rest of the configuration.
 
 from __future__ import annotations
 
-from typing import Literal, Optional
+from typing import Literal
 
 from pydantic import Field
 from safir.pydantic import CamelCaseModel
@@ -138,7 +138,7 @@ class PrepullerConfig(CamelCaseModel):
         ),
         ge=0,
     )
-    cycle: Optional[int] = Field(
+    cycle: int | None = Field(
         None,
         examples=[27],
         title="Limit to this cycle number (XML schema version)",
@@ -150,7 +150,7 @@ class PrepullerConfig(CamelCaseModel):
             " spawner menu."
         ),
     )
-    pin: Optional[list[str]] = Field(
+    pin: list[str] | None = Field(
         None,
         examples=[["d_2077_10_23"]],
         title="List of image tags to prepull and pin to the menu",

--- a/src/jupyterlabcontroller/services/builder.py
+++ b/src/jupyterlabcontroller/services/builder.py
@@ -87,7 +87,7 @@ class LabBuilder:
 
         Returns
         -------
-        dict of str to str
+        dict of str
             Equivalent environment sent by JupyterHub.
 
         Notes

--- a/src/jupyterlabcontroller/services/builder.py
+++ b/src/jupyterlabcontroller/services/builder.py
@@ -96,22 +96,20 @@ class LabBuilder:
         the lab controller must be kept in sync with the code that creates the
         config map.
         """
-        unwanted = set(
-            (
-                "CPU_GUARANTEE",
-                "CPU_LIMIT",
-                "DEBUG",
-                "EXTERNAL_INSTANCE_URL",
-                "IMAGE_DESCRIPTION",
-                "IMAGE_DIGEST",
-                "JUPYTER_IMAGE",
-                "JUPYTER_IMAGE_SPEC",
-                "MEM_GUARANTEE",
-                "MEM_LIMIT",
-                "RESET_USER_ENV",
-                *list(self._config.env.keys()),
-            )
-        )
+        unwanted = {
+            "CPU_GUARANTEE",
+            "CPU_LIMIT",
+            "DEBUG",
+            "EXTERNAL_INSTANCE_URL",
+            "IMAGE_DESCRIPTION",
+            "IMAGE_DIGEST",
+            "JUPYTER_IMAGE",
+            "JUPYTER_IMAGE_SPEC",
+            "MEM_GUARANTEE",
+            "MEM_LIMIT",
+            "RESET_USER_ENV",
+            *list(self._config.env.keys()),
+        }
         return {k: v for k, v in env.items() if k not in unwanted}
 
     def namespace_for_user(self, username: str) -> str:

--- a/src/jupyterlabcontroller/services/fileserver.py
+++ b/src/jupyterlabcontroller/services/fileserver.py
@@ -78,11 +78,12 @@ class FileserverStateManager:
         ):
             try:
                 await self._create_fileserver(user)
-            except Exception as exc:
-                self._logger.error(
-                    f"Fileserver creation for {username} failed with {exc}"
-                    + ": deleting fileserver objects."
+            except Exception:
+                msg = (
+                    f"Fileserver creation for {username} failed, deleting"
+                    " fileserver objects"
                 )
+                self._logger.exception(msg)
                 await self.delete(username)
                 raise
 
@@ -98,7 +99,7 @@ class FileserverStateManager:
             service = self._build_fileserver_service(user.username)
             job = self._build_fileserver_job(user)
             self._logger.debug(
-                "...creating new gafawelfawrfingress for " + username
+                f"...creating new GafaelfawrIngress for {username}"
             )
             await self._k8s_client.create_fileserver_gafaelfawringress(
                 namespace, gf_ingress
@@ -290,7 +291,7 @@ class FileserverStateManager:
         )
 
         # _Build the pod specification itself.
-        # FIXME work out tolerations
+        # TODO(athornton): work out tolerations
         return V1PodSpec(
             containers=[container],
             restart_policy="Never",

--- a/src/jupyterlabcontroller/services/form.py
+++ b/src/jupyterlabcontroller/services/form.py
@@ -14,7 +14,7 @@ class FormManager:
         image_service: ImageService,
         lab_sizes: dict[LabSize, LabSizeDefinition],
         logger: BoundLogger,
-    ):
+    ) -> None:
         self._image_service = image_service
         self._logger = logger
         self._lab_sizes = lab_sizes
@@ -23,13 +23,12 @@ class FormManager:
         options_template = Template(SPAWNER_FORM_TEMPLATE)
         images = self._image_service.menu_images()
         sizes = self._extract_sizes()
-        rendered = options_template.render(
+        return options_template.render(
             dropdown_sentinel=DROPDOWN_SENTINEL_VALUE,
             cached_images=images.menu,
             all_images=images.dropdown,
             sizes=sizes,
         )
-        return rendered
 
     def _extract_sizes(self) -> list[FormSize]:
         sz = self._lab_sizes

--- a/src/jupyterlabcontroller/services/image.py
+++ b/src/jupyterlabcontroller/services/image.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Optional
 
 from aiojobs import Scheduler
 from safir.datetime import current_datetime
@@ -74,7 +73,7 @@ class ImageService:
         config: PrepullerConfig,
         source: ImageSource,
         kubernetes: K8sStorageClient,
-        slack_client: Optional[SlackWebhookClient] = None,
+        slack_client: SlackWebhookClient | None = None,
         logger: BoundLogger,
     ) -> None:
         self._config = config
@@ -84,7 +83,7 @@ class ImageService:
         self._logger = logger
 
         # Background task management.
-        self._scheduler: Optional[Scheduler] = None
+        self._scheduler: Scheduler | None = None
         self._lock = asyncio.Lock()
         self._refreshed = asyncio.Event()
 
@@ -275,7 +274,7 @@ class ImageService:
             Model suitable for returning from a handler.
         """
         all_nodes = set(self._node_images.keys())
-        nodes = {n: Node(name=n) for n in self._node_images.keys()}
+        nodes = {n: Node(name=n) for n in self._node_images}
         prepulled = []
         pending = []
         for image in self._to_prepull.all_images(hide_resolved_aliases=True):

--- a/src/jupyterlabcontroller/services/lab.py
+++ b/src/jupyterlabcontroller/services/lab.py
@@ -749,16 +749,7 @@ class LabManager:
                     ),
                 ],
                 image=ic.image,
-                resources=V1ResourceRequirements(
-                    limits={
-                        "cpu": str(resources.limits.cpu),
-                        "memory": str(resources.limits.memory),
-                    },
-                    requests={
-                        "cpu": str(resources.requests.cpu),
-                        "memory": str(resources.requests.memory),
-                    },
-                ),
+                resources=resources.to_kubernetes(),
                 security_context=ic_sec_ctx,
                 volume_mounts=ic_vol_mounts,
             )
@@ -848,16 +839,7 @@ class LabManager:
             image=image.reference_with_digest,
             image_pull_policy="IfNotPresent",
             ports=[V1ContainerPort(container_port=8888, name="jupyterlab")],
-            resources=V1ResourceRequirements(
-                limits={
-                    "cpu": str(resources.limits.cpu),
-                    "memory": str(resources.limits.memory),
-                },
-                requests={
-                    "cpu": str(resources.requests.cpu),
-                    "memory": str(resources.requests.memory),
-                },
-            ),
+            resources=resources.to_kubernetes(),
             security_context=V1SecurityContext(
                 run_as_non_root=True,
                 run_as_user=user.uid,

--- a/src/jupyterlabcontroller/services/lab.py
+++ b/src/jupyterlabcontroller/services/lab.py
@@ -7,7 +7,6 @@ import re
 from copy import copy
 from functools import partial
 from pathlib import Path
-from typing import Optional
 
 from kubernetes_asyncio.client import (
     V1ConfigMapEnvSource,
@@ -75,7 +74,7 @@ class LabManager:
         logger: BoundLogger,
         lab_config: LabConfig,
         k8s_client: K8sStorageClient,
-        slack_client: Optional[SlackWebhookClient] = None,
+        slack_client: SlackWebhookClient | None = None,
     ) -> None:
         self.manager_namespace = manager_namespace
         self.instance_url = instance_url
@@ -451,11 +450,11 @@ class LabManager:
 
         # Add standard environment variables.
         resources = self._size_manager.resources(lab.options.size)
-        size_str = [
+        size_str = next(
             x.description
             for x in self._size_manager.formdata()
             if x.name == lab.options.size.value.title()
-        ][0]
+        )
         env.update(
             {
                 # We would like to deprecate this, following KubeSpawner, but
@@ -574,7 +573,7 @@ class LabManager:
         # preferably be referred to by that path, although we also support
         # injecting them into environment variables and other paths for ease
         # of transition.
-        sec_vol = LabVolumeContainer(
+        return LabVolumeContainer(
             volume=V1Volume(
                 name=f"{username}-nb-secrets",
                 secret=V1SecretVolumeSource(
@@ -587,7 +586,6 @@ class LabManager:
                 read_only=True,
             ),
         )
-        return sec_vol
 
     def build_extra_secret_volume_mounts(
         self, username: str
@@ -621,7 +619,7 @@ class LabManager:
         #
         # Step five: environment
         #
-        env_vol = LabVolumeContainer(
+        return LabVolumeContainer(
             volume=V1Volume(
                 name=f"{username}-nb-env",
                 config_map=V1ConfigMapVolumeSource(
@@ -634,7 +632,6 @@ class LabManager:
                 read_only=False,  # We'd like to be able to update this
             ),
         )
-        return env_vol
 
     def build_tmp_volume(self) -> LabVolumeContainer:
         return LabVolumeContainer(
@@ -659,9 +656,6 @@ class LabManager:
         # Except we can't have it:
         # https://github.com/kubernetes/kubernetes/issues/64168
         # So we will inject it into the env instead.
-        # volfields = [
-        #    "spec.nodeName",
-        # ]
         resfields = [
             "limits.cpu",
             "requests.cpu",
@@ -681,7 +675,7 @@ class LabManager:
                 for x in resfields
             ]
         )
-        runtime_vol = LabVolumeContainer(
+        return LabVolumeContainer(
             volume=V1Volume(
                 name=f"{username}-nb-runtime",
                 downward_api=V1DownwardAPIVolumeSource(items=volfiles),
@@ -692,7 +686,6 @@ class LabManager:
                 read_only=True,
             ),
         )
-        return runtime_vol
 
     def build_volumes(self, username: str) -> list[LabVolumeContainer]:
         """This stitches together the Volume and VolumeMount definitions
@@ -880,7 +873,7 @@ class LabManager:
         if self.lab_config.pull_secret:
             pull_secrets = [V1LocalObjectReference(name="pull-secret")]
         init_containers = self.build_init_containers(user, resources)
-        pod = V1PodSpec(
+        return V1PodSpec(
             init_containers=init_containers,
             containers=[container],
             image_pull_secrets=pull_secrets,
@@ -890,7 +883,6 @@ class LabManager:
             ),
             volumes=volumes,
         )
-        return pod
 
     async def delete_lab(self, username: str) -> None:
         """Delete the lab environment for the given user.

--- a/src/jupyterlabcontroller/services/lab.py
+++ b/src/jupyterlabcontroller/services/lab.py
@@ -535,7 +535,7 @@ class LabManager:
         for cfile in self.lab_config.files:
             dscfile = deslashify(cfile)
             cmname = f"{username}-nb-configmap"
-            if cfile == "/etc/passwd" or cfile == "/etc/group":
+            if cfile in {"/etc/passwd", "/etc/group"}:
                 cmname = f"{username}-nb-nss"
             path = Path(cfile)
             bname = str(path.name)
@@ -868,7 +868,7 @@ class LabManager:
         )
 
         # Build the pod specification itself.
-        # FIXME work out tolerations
+        # TODO(athornton): work out tolerations
         pull_secrets = None
         if self.lab_config.pull_secret:
             pull_secrets = [V1LocalObjectReference(name="pull-secret")]

--- a/src/jupyterlabcontroller/services/prepuller.py
+++ b/src/jupyterlabcontroller/services/prepuller.py
@@ -3,7 +3,6 @@
 import asyncio
 import re
 from pathlib import Path
-from typing import Optional
 
 from aiojobs import Scheduler
 from kubernetes_asyncio.client import (
@@ -58,8 +57,8 @@ class Prepuller:
         metadata_path: Path,
         image_service: ImageService,
         k8s_client: K8sStorageClient,
-        slack_client: Optional[SlackWebhookClient] = None,
-        pull_secret: Optional[str] = None,
+        slack_client: SlackWebhookClient | None = None,
+        pull_secret: str | None = None,
         logger: BoundLogger,
     ) -> None:
         self._namespace = namespace
@@ -71,7 +70,7 @@ class Prepuller:
         self._logger = logger
 
         # Scheduler to manage background tasks that prepull images to nodes.
-        self._scheduler: Optional[Scheduler] = None
+        self._scheduler: Scheduler | None = None
 
     async def start(self) -> None:
         if self._scheduler:

--- a/src/jupyterlabcontroller/services/size.py
+++ b/src/jupyterlabcontroller/services/size.py
@@ -1,5 +1,4 @@
-"""Image size service.  It takes the set of lab sizes from the config
-in its constructor."""
+"""Image size service."""
 
 import bitmath
 
@@ -16,12 +15,26 @@ def memory_string_to_int(memstr: str) -> int:
 
 
 class SizeManager:
+    """Operations on image sizes.
+
+    Parameters
+    ----------
+    sizes
+        Size definitions from the lab controller configuration.
+    """
+
     def __init__(self, sizes: dict[LabSize, LabSizeDefinition]) -> None:
         self._sizes = sizes
 
     def formdata(self) -> list[FormSize]:
-        """Return the text representation of our sizes in a format suitable
-        for injecting into the user spawner form"""
+        """Return available sizes for injecting into the spawner form.
+
+        Returns
+        -------
+        list of FormSize
+            Representation of sizes suitable for injecting into the user
+            spawner form.
+        """
         return [
             FormSize(
                 name=x.value.title(),

--- a/src/jupyterlabcontroller/services/source/base.py
+++ b/src/jupyterlabcontroller/services/source/base.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
-from typing import Mapping
+from collections.abc import Mapping
 
 from structlog.stdlib import BoundLogger
 

--- a/src/jupyterlabcontroller/services/source/docker.py
+++ b/src/jupyterlabcontroller/services/source/docker.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Mapping
+from collections.abc import Mapping
 
 from structlog.stdlib import BoundLogger
 

--- a/src/jupyterlabcontroller/services/source/docker.py
+++ b/src/jupyterlabcontroller/services/source/docker.py
@@ -291,7 +291,7 @@ class DockerImageSource(ImageSource):
 
         # Construct the images.
         images = []
-        for tag, digest in zip(to_prepull.all_tags(), digests):
+        for tag, digest in zip(to_prepull.all_tags(), digests, strict=True):
             image = RSPImage.from_tag(
                 registry=self._config.registry,
                 repository=self._config.repository,

--- a/src/jupyterlabcontroller/services/source/gar.py
+++ b/src/jupyterlabcontroller/services/source/gar.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Mapping
+from collections.abc import Mapping
 
 from structlog.stdlib import BoundLogger
 

--- a/src/jupyterlabcontroller/services/state.py
+++ b/src/jupyterlabcontroller/services/state.py
@@ -599,7 +599,7 @@ class LabStateManager:
         env = env_map.data
         if not pod:
             msg = f"No {pod_name} Pod for {username}"
-            self._logger.warning(msg, name=pod_name)
+            logger.warning(msg, name=pod_name)
             return None
 
         # Find the lab container.

--- a/src/jupyterlabcontroller/services/state.py
+++ b/src/jupyterlabcontroller/services/state.py
@@ -195,11 +195,12 @@ class LabStateManager:
         """
         try:
             state = await self.get_lab_state(username)
-            return state.status
         except UnknownUserError:
             return None
+        else:
+            return state.status
 
-    async def list_lab_users(self, only_running: bool = False) -> list[str]:
+    async def list_lab_users(self, *, only_running: bool = False) -> list[str]:
         """List all users with labs.
 
         Parameters
@@ -223,7 +224,7 @@ class LabStateManager:
             return list(self._labs.keys())
 
     async def publish_error(
-        self, username: str, message: str, fatal: bool = False
+        self, username: str, message: str, *, fatal: bool = False
     ) -> None:
         """Publish a lab spawn or deletion failure event for a user.
 
@@ -374,7 +375,7 @@ class LabStateManager:
         except TimeoutError:
             delay = int((current_datetime() - start).total_seconds())
             msg = f"Lab deletion timed out after {delay}s"
-            logger.error(msg)
+            logger.exception(msg)
             event = Event(message=msg, type=EventType.FAILED)
             self._labs[username].events.put(event)
             self._labs[username].events.close()
@@ -680,7 +681,8 @@ class LabStateManager:
             )
         except Exception as e:
             error = f"{type(e).__name__}: {e!s}"
-            logger.error(f"Invalid lab environment for {username}: {error}")
+            msg = f"Invalid lab environment for {username}: {error}"
+            logger.exception(msg)
             return None
 
     def _recreate_groups(self, pod: V1Pod) -> list[UserGroup]:

--- a/src/jupyterlabcontroller/services/state.py
+++ b/src/jupyterlabcontroller/services/state.py
@@ -602,16 +602,21 @@ class LabStateManager:
             self._logger.warning(msg, name=pod_name)
             return None
 
+        # Find the lab container.
+        lab_container = None
+        for container in pod.spec.containers:
+            if container.name == "notebook":
+                lab_container = container
+                break
+        if not lab_container:
+            error = 'No container named "notebook"'
+            msg = f"Invalid lab environment for {username}: {error}"
+            logger.error(msg)
+            return None
+
         # Gather the necessary information from the pod. If anything is
         # missing or in an unexpected format, log an error and return None.
         try:
-            lab_container = None
-            for container in pod.spec.containers:
-                if container.name == "notebook":
-                    lab_container = container
-                    break
-            if not lab_container:
-                raise ValueError('No container named "notebook"')
             resources = LabResources(
                 limits=ResourceQuantity(
                     cpu=float(env["CPU_LIMIT"]),

--- a/src/jupyterlabcontroller/storage/docker.py
+++ b/src/jupyterlabcontroller/storage/docker.py
@@ -143,6 +143,13 @@ class DockerStorageClient:
                 r = await self._client.get(url, headers=headers)
             r.raise_for_status()
             tags = r.json()["tags"]
+        except HTTPError as e:
+            raise DockerRegistryError.from_exception(e) from e
+        except Exception as e:
+            error = f"{type(e).__name__}: {e!s}"
+            msg = f"Cannot parse response from Docker registry: {error}"
+            raise DockerRegistryError(msg, method="GET", url=url) from e
+        else:
             self._logger.debug(
                 "Listed all image tags",
                 registry=config.registry,
@@ -150,12 +157,6 @@ class DockerStorageClient:
                 count=len(tags),
             )
             return tags
-        except HTTPError as e:
-            raise DockerRegistryError.from_exception(e) from e
-        except Exception as e:
-            error = f"{type(e).__name__}: {e!s}"
-            msg = f"Cannot parse response from Docker registry: {error}"
-            raise DockerRegistryError(msg, method="GET", url=url)
 
     async def get_image_digest(
         self, config: DockerSourceConfig, tag: str
@@ -190,6 +191,13 @@ class DockerStorageClient:
                 r = await self._client.head(url, headers=headers)
             r.raise_for_status()
             digest = r.headers["Docker-Content-Digest"]
+        except HTTPError as e:
+            raise DockerRegistryError.from_exception(e) from e
+        except Exception as e:
+            error = f"{type(e).__name__}: {e!s}"
+            msg = f"Cannot get image digest from Docker registry: {error}"
+            raise DockerRegistryError(msg, method="GET", url=url) from e
+        else:
             self._logger.debug(
                 "Retrieved image digest for tag",
                 registry=config.registry,
@@ -198,12 +206,6 @@ class DockerStorageClient:
                 digest=digest,
             )
             return digest
-        except HTTPError as e:
-            raise DockerRegistryError.from_exception(e) from e
-        except Exception as e:
-            error = f"{type(e).__name__}: {e!s}"
-            msg = f"Cannot get image digest from Docker registry: {error}"
-            raise DockerRegistryError(msg, method="GET", url=url)
 
     async def _authenticate(
         self, host: str, response: Response
@@ -346,4 +348,4 @@ class DockerStorageClient:
         except Exception as e:
             error = f"{type(e).__name__}: {e!s}"
             msg = f"Cannot parse Docker registry login response: {error}"
-            raise DockerRegistryError(msg, method="GET", url=url)
+            raise DockerRegistryError(msg, method="GET", url=url) from e

--- a/src/jupyterlabcontroller/storage/docker.py
+++ b/src/jupyterlabcontroller/storage/docker.py
@@ -153,7 +153,7 @@ class DockerStorageClient:
         except HTTPError as e:
             raise DockerRegistryError.from_exception(e) from e
         except Exception as e:
-            error = f"{type(e).__name__}: {str(e)}"
+            error = f"{type(e).__name__}: {e!s}"
             msg = f"Cannot parse response from Docker registry: {error}"
             raise DockerRegistryError(msg, method="GET", url=url)
 
@@ -201,7 +201,7 @@ class DockerStorageClient:
         except HTTPError as e:
             raise DockerRegistryError.from_exception(e) from e
         except Exception as e:
-            error = f"{type(e).__name__}: {str(e)}"
+            error = f"{type(e).__name__}: {e!s}"
             msg = f"Cannot get image digest from Docker registry: {error}"
             raise DockerRegistryError(msg, method="GET", url=url)
 
@@ -344,6 +344,6 @@ class DockerStorageClient:
         except HTTPError as e:
             raise DockerRegistryError.from_exception(e) from e
         except Exception as e:
-            error = f"{type(e).__name__}: {str(e)}"
+            error = f"{type(e).__name__}: {e!s}"
             msg = f"Cannot parse Docker registry login response: {error}"
             raise DockerRegistryError(msg, method="GET", url=url)

--- a/src/jupyterlabcontroller/storage/gar.py
+++ b/src/jupyterlabcontroller/storage/gar.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from google.cloud import artifactregistry_v1
 from google.cloud.artifactregistry_v1 import ListDockerImagesRequest
 from structlog.stdlib import BoundLogger
@@ -33,7 +31,7 @@ class GARStorageClient:
         self._client = artifactregistry_v1.ArtifactRegistryAsyncClient()
 
     async def list_images(
-        self, config: GARSourceConfig, cycle: Optional[int] = None
+        self, config: GARSourceConfig, cycle: int | None = None
     ) -> RSPImageCollection:
         """Return all images stored in the remote repository.
 

--- a/src/jupyterlabcontroller/storage/k8s.py
+++ b/src/jupyterlabcontroller/storage/k8s.py
@@ -413,6 +413,7 @@ class K8sStorageClient:
         namespace: str,
         data: dict[str, str],
         secret_type: str = "Opaque",
+        *,
         immutable: bool = True,
     ) -> None:
         secret = V1Secret(
@@ -449,6 +450,7 @@ class K8sStorageClient:
         name: str,
         namespace: str,
         data: dict[str, str],
+        *,
         immutable: bool = True,
     ) -> None:
         configmap = V1ConfigMap(
@@ -459,9 +461,9 @@ class K8sStorageClient:
         await self._config_map.create(namespace, configmap)
 
     async def create_network_policy(self, name: str, namespace: str) -> None:
-        # FIXME we need to further restrict Ingress to the right pods,
-        # and Egress to ... external world, Hub, Portal, Gafaelfawr.  What
-        # else?
+        # TODO(athornton): we need to further restrict Ingress to the right
+        # pods, and Egress to ... external world, Hub, Portal, Gafaelfawr.
+        # What else?
         policy = V1NetworkPolicy(
             metadata=self.standard_metadata(name, namespace=namespace),
             spec=V1NetworkPolicySpec(
@@ -556,7 +558,7 @@ class K8sStorageClient:
         pod = V1Pod(metadata=metadata, spec=pod_spec)
         await self._pod.create(namespace, pod, replace=remove_on_conflict)
 
-    async def delete_namespace(self, name: str, wait: bool = False) -> None:
+    async def delete_namespace(self, name: str, *, wait: bool = False) -> None:
         """Delete a Kubernetes namespace.
 
         If the namespace doesn't exist, the deletion is silently successful.
@@ -823,16 +825,18 @@ class K8sStorageClient:
     async def check_fileserver_present(
         self, username: str, namespace: str
     ) -> bool:
-        """Our determination of whether a user has a fileserver is this:
+        """Check if a file server is present.
+
+        Our determination of whether a user has a fileserver is this:
 
         We assume all fileserver objects are named <username>-fs, which we
         can do, since we created them and that's the convention we chose.
 
         A fileserver is working if:
 
-        1) it has exactly one Pod in Running state due to a Job of the
+        #. it has exactly one Pod in Running state due to a Job of the
            right name, and
-        2) it has an Ingress, which has status.load_balancer.ingress, and
+        #. it has an Ingress, which has status.load_balancer.ingress, and
            that inner ingress has an attribute "ip" which is not the
            empty string.
 
@@ -862,7 +866,7 @@ class K8sStorageClient:
         if pod.status.phase != "Running":
             self._logger.info(
                 f"Pod for {username} is in phase "
-                + f"'{pod.status.phase}', not 'Running'."
+                f"'{pod.status.phase}', not 'Running'."
             )
             return False
         self._logger.debug(f"...checking Ingress for {username}")

--- a/src/jupyterlabcontroller/storage/kubernetes/watcher.py
+++ b/src/jupyterlabcontroller/storage/kubernetes/watcher.py
@@ -53,7 +53,7 @@ class WatchEvent(Generic[T]):
 
         Raises
         ------
-        ValueError
+        TypeError
             Raised if the type of the object in the watch event was incorrect.
         """
         action = WatchEventType(event["type"])
@@ -64,7 +64,7 @@ class WatchEvent(Generic[T]):
             real_type = type(obj).__name__
             expected_type = object_type.__name__
             msg = f"Watch object was of type {real_type}, not {expected_type}"
-            raise ValueError(msg)
+            raise TypeError(msg)
         return cls(action=action, object=obj)
 
 

--- a/src/jupyterlabcontroller/util.py
+++ b/src/jupyterlabcontroller/util.py
@@ -38,13 +38,13 @@ def seconds_to_phrase(seconds: int) -> str:
     days, seconds = divmod(seconds, 86400)
     hours, seconds = divmod(seconds, 3600)
     minutes, seconds = divmod(seconds, 60)
-    str = ""
+    string = ""
     if days:
-        str = f"{days}d"
+        string = f"{days}d"
     if hours:
-        str += f"{hours}h"
+        string += f"{hours}h"
     if minutes:
-        str += f"{minutes}m"
+        string += f"{minutes}m"
     if seconds:
-        str += f"{seconds}s"
-    return str
+        string += f"{seconds}s"
+    return string

--- a/src/jupyterlabcontroller/util.py
+++ b/src/jupyterlabcontroller/util.py
@@ -10,7 +10,7 @@ def deslashify(data: str) -> str:
 
 
 def metadata_to_dict(metadata_object: V1ObjectMeta) -> dict[str, Any]:
-    """Return the dict representation of a Kubernetes metadata object
+    """Return the dict representation of a Kubernetes metadata object.
 
     Parameters
     ----------
@@ -24,7 +24,6 @@ def metadata_to_dict(metadata_object: V1ObjectMeta) -> dict[str, Any]:
         custom resources, which require dicts rather than Kubernetes
         objects.
     """
-
     md_obj = {
         "name": metadata_object.name,
         "annotations": metadata_object.annotations,

--- a/tests/fileserver/conftest.py
+++ b/tests/fileserver/conftest.py
@@ -1,6 +1,9 @@
-"""Test fixtures for jupyterlab-controller tests that require a running
-fileserver.  This requires a different application, configuration, factory,
-and so on."""
+"""Test fixtures for testing the file server.
+
+Test fixtures for jupyterlab-controller tests that require a running
+fileserver. This requires a different application, configuration, factory, and
+so on.
+"""
 
 from __future__ import annotations
 

--- a/tests/fileserver/handlers/object_cleanup_on_exit_test.py
+++ b/tests/fileserver/handlers/object_cleanup_on_exit_test.py
@@ -25,7 +25,7 @@ def _find_user_pod(user: str, objects: list[Any]) -> V1Pod:
             for lbl in obj.metadata.labels:
                 if lbl == "job-name" and obj.metadata.labels[lbl] == obj_name:
                     return obj
-    assert False, f"Could not find pod for user {user}"
+    raise AssertionError(f"Could not find pod for user {user}")
 
 
 @pytest.mark.asyncio
@@ -92,8 +92,7 @@ async def test_cleanup_on_pod_exit(
     # the mock doesn't remove the ingress on GafaelfawrIngress
     # deletion like the real thing does), and will still have the
     # Namespace.  So let's check that.
-    assert len(objs) == 2 and set(x.kind for x in objs) == set(
-        ["Ingress", "Namespace"]
-    )
+    assert len(objs) == 2
+    assert {x.kind for x in objs} == {"Ingress", "Namespace"}
     # Clean up the Ingress
     await delete_ingress_for_user(mock_kubernetes, name, namespace)

--- a/tests/handlers/volume_cases_test.py
+++ b/tests/handlers/volume_cases_test.py
@@ -38,16 +38,10 @@ async def test_volume_cases(
     pod = await mock_kubernetes.read_namespaced_pod(pod_name, namespace)
     ctr = pod.spec.containers[0]
     # lowercase works the same
-    assert (
-        ctr.volume_mounts[0].mount_path == "/home"
-        and ctr.volume_mounts[0].name == "home"
-    )
+    assert ctr.volume_mounts[0].mount_path == "/home"
+    assert ctr.volume_mounts[0].name == "home"
     # but upper and mixed-case are squashed to lower in object name
-    assert (
-        ctr.volume_mounts[1].mount_path == "/PROJECT"
-        and ctr.volume_mounts[1].name == "project"
-    )
-    assert (
-        ctr.volume_mounts[2].mount_path == "/ScRaTcH"
-        and ctr.volume_mounts[2].name == "scratch"
-    )
+    assert ctr.volume_mounts[1].mount_path == "/PROJECT"
+    assert ctr.volume_mounts[1].name == "project"
+    assert ctr.volume_mounts[2].mount_path == "/ScRaTcH"
+    assert ctr.volume_mounts[2].name == "scratch"

--- a/tests/models/domain/rspimage_test.py
+++ b/tests/models/domain/rspimage_test.py
@@ -114,7 +114,7 @@ def test_resolve_alias() -> None:
     )
 
     # Can't resolve some other image type.
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"Can only resolve.*"):
         image.resolve_alias(latest_daily)
 
 

--- a/tests/models/domain/rspimage_test.py
+++ b/tests/models/domain/rspimage_test.py
@@ -173,7 +173,7 @@ def test_collection() -> None:
 
     # Test all_images, its sorting, and its filtering options.
     all_images = [i.tag for i in collection.all_images()]
-    assert all_images == ["recommended", "latest_weekly"] + tags
+    assert all_images == ["recommended", "latest_weekly", *tags]
     without_aliases = collection.all_images(hide_resolved_aliases=True)
     assert [i.tag for i in without_aliases] == tags
     assert [i.tag for i in collection.all_images(hide_aliased=True)] == [

--- a/tests/models/domain/rsptag_test.py
+++ b/tests/models/domain/rsptag_test.py
@@ -31,9 +31,9 @@ def test_tag_ordering() -> None:
     assert three == three
     assert one != three
     with pytest.raises(TypeError):
-        one < three
+        assert one < three
     with pytest.raises(TypeError):
-        one > three
+        assert one > three
 
     four = RSPImageTag.from_str("d_2023_02_10_c0030.004")
     assert three != four

--- a/tests/models/domain/rsptag_test.py
+++ b/tests/models/domain/rsptag_test.py
@@ -29,7 +29,7 @@ def test_tag_ordering() -> None:
 
     three = RSPImageTag.from_str("d_2023_02_09")
     assert three == three
-    assert not one == three
+    assert one != three
     with pytest.raises(TypeError):
         one < three
     with pytest.raises(TypeError):

--- a/tests/services/prepuller_test.py
+++ b/tests/services/prepuller_test.py
@@ -168,7 +168,7 @@ async def test_gar(
             f"prepull-{tag}-node1",
             f"prepull-{tag}-node2",
         ]
-        assert all([not p.metadata.owner_references for p in pod_list.items])
+        assert all(not p.metadata.owner_references for p in pod_list.items)
 
         # Mark those nodes as complete, and two more should be started.
         for pod in pod_list.items:

--- a/tests/services/state_test.py
+++ b/tests/services/state_test.py
@@ -218,6 +218,7 @@ async def test_spawn_timeout(
     events = []
     async for event in factory.lab_state.events_for_user(user.username):
         events.append(event)
-    assert events[-2].data and events[-1].data
+    assert events[-2].data
+    assert events[-1].data
     assert "Lab creation timed out after" in events[-2].data
     assert "Lab creation failed" in events[-1].data

--- a/tests/services/state_test.py
+++ b/tests/services/state_test.py
@@ -215,9 +215,9 @@ async def test_spawn_timeout(
     await asyncio.sleep(0.5)
     status = await factory.lab_state.get_lab_status(user.username)
     assert status == LabStatus.FAILED
-    events = []
-    async for event in factory.lab_state.events_for_user(user.username):
-        events.append(event)
+    events = [
+        e async for e in factory.lab_state.events_for_user(user.username)
+    ]
     assert events[-2].data
     assert events[-1].data
     assert "Lab creation timed out after" in events[-2].data

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,4 +1,4 @@
-"""Produce a test object factory"""
+"""Produce a test object factory."""
 
 from __future__ import annotations
 
@@ -108,7 +108,7 @@ class TestObjectFactory:
         """Get user information and token for a user."""
         for token, user in self.userinfos.items():
             return token, user
-        assert False, "No user information records configured"
+        raise AssertionError("No user information records configured")
 
 
 test_object_factory = TestObjectFactory()

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import json
 from base64 import b64encode
-from typing import Any
+from pathlib import Path
+from typing import Any, ClassVar
 
 from kubernetes_asyncio.client import (
     V1ContainerImage,
@@ -22,37 +23,39 @@ from jupyterlabcontroller.services.size import memory_string_to_int
 
 
 class TestObjectFactory:
-    _filename = ""
-    _canonicalized = False
-    test_objects: dict[str, Any] = {}
+    _filename: ClassVar[str] = ""
+    _canonicalized: ClassVar[bool] = False
+    test_objects: ClassVar[dict[str, Any]] = {}
 
-    def initialize_from_file(self, filename: str) -> None:
-        if filename and filename != self._filename:
-            with open(filename) as f:
-                self.test_objects = json.load(f)
-                self._filename = filename
-            self.canonicalize()
+    @classmethod
+    def initialize_from_file(cls, filename: str) -> None:
+        if filename and filename != cls._filename:
+            with Path(filename).open() as f:
+                cls.test_objects = json.load(f)
+                cls._filename = filename
+            cls.canonicalize()
 
-    def canonicalize(self) -> None:
-        if self._canonicalized:
+    @classmethod
+    def canonicalize(cls) -> None:
+        if cls._canonicalized:
             return
-        for idx, x in enumerate(self.test_objects["user_options"]):
+        for idx, x in enumerate(cls.test_objects["user_options"]):
             # Glue options and envs into lab specifications
-            self.test_objects["lab_specification"].append(
+            cls.test_objects["lab_specification"].append(
                 {
                     "options": x,
-                    "env": self.test_objects["env"][
-                        idx % len(self.test_objects["env"])
+                    "env": cls.test_objects["env"][
+                        idx % len(cls.test_objects["env"])
                     ],
                 }
             )
             # Set memory to bytes rather than text (e.g. "3KiB" -> 3072)
-            for q in self.test_objects["resources"]:
+            for q in cls.test_objects["resources"]:
                 for i in ("limits", "requests"):
                     memfld = q[i]["memory"]
-                    if type(memfld) is str:
+                    if isinstance(memfld, str):
                         q[i]["memory"] = memory_string_to_int(memfld)
-        self._canonicalized = True
+        cls._canonicalized = True
 
     @property
     def userinfos(self) -> dict[str, GafaelfawrUserInfo]:

--- a/tests/support/docker.py
+++ b/tests/support/docker.py
@@ -42,6 +42,7 @@ class MockDockerRegistry:
         tags: dict[str, str],
         realm: str,
         credentials: DockerCredentials,
+        *,
         require_bearer: bool = False,
     ) -> None:
         self.tags = tags
@@ -199,7 +200,9 @@ def register_mock_docker(
     store = DockerCredentialStore.from_path(credentials_path)
     credentials = store.get(host)
     assert credentials
-    mock = MockDockerRegistry(tags, auth_url, credentials, require_bearer)
+    mock = MockDockerRegistry(
+        tags, auth_url, credentials, require_bearer=require_bearer
+    )
 
     respx_mock.get(base_url + "/auth").mock(side_effect=mock.authenticate)
     respx_mock.get(tags_url).mock(side_effect=mock.list_tags)


### PR DESCRIPTION
Switched from isort and flake8 to Ruff for linting, and added a check for merge conflicts and an invocation of blacken-docs. The latter isn't used yet, but may be in the future.

Applied all the Ruff autofixes and fixed all remaining errors other than those about complexity and docstrings, which aren't worth fixing right now since a lot of them will be fixed naturally after refactoring. Told Ruff to not warn about functions with lots of returns, since often this is clearer code. Temporarily exclude Ruff warnings about docstrings and complexity until we're through other refactoring.

Refactored the code for waiting for lab spawn and recreating lab state to reduce complexity and remove some cases of throwing exceptions inside try/catch blocks that catch that same exception. Refactored how `V1ResourceRequirements` objects were created to avoid a lot of code duplication.