### PR TITLE
DM-40813: Refactor prepuller storage layer

### DIFF
--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -1,2 +1,3 @@
 .. _d20 creature sizes: https://www.d20srd.org/srd/combat/movementPositionAndDistance.htm#bigandLittleCreaturesInCombat
+.. _downward API: https://kubernetes.io/docs/concepts/workloads/pods/downward-api/
 .. _kubernetes_asyncio: https://github.com/tomplus/kubernetes_asyncio

--- a/src/jupyterlabcontroller/constants.py
+++ b/src/jupyterlabcontroller/constants.py
@@ -13,6 +13,7 @@ __all__ = [
     "KUBERNETES_REQUEST_TIMEOUT",
     "LAB_STATE_REFRESH_INTERVAL",
     "LIMIT_TO_REQUEST_RATIO",
+    "PREPULLER_POD_TIMEOUT",
     "METADATA_PATH",
     "SPAWNER_FORM_TEMPLATE",
     "USERNAME_REGEX",
@@ -56,6 +57,13 @@ to the lab spammed alert messages about missing files, presumably from the
 JavaScript calls to the lab failing. Kubespawner uses a grace period of 1s and
 appears to assume the lab will not do anything useful in repsonse to SIGTERM,
 so copy its behavior.
+"""
+
+PREPULLER_POD_TIMEOUT = timedelta(minutes=10)
+"""How long to wait for a prepuller pod to spawn and finish running.
+
+This may take a substantial amount of time if the pod image is quite large or
+the network is slow.
 """
 
 METADATA_PATH = Path("/etc/podinfo")

--- a/src/jupyterlabcontroller/services/builder.py
+++ b/src/jupyterlabcontroller/services/builder.py
@@ -2,10 +2,17 @@
 
 from __future__ import annotations
 
+import re
+
 from kubernetes_asyncio.client import (
+    V1Container,
     V1HostPathVolumeSource,
+    V1LocalObjectReference,
     V1NFSVolumeSource,
+    V1ObjectMeta,
     V1PersistentVolumeClaimVolumeSource,
+    V1Pod,
+    V1PodSpec,
     V1Volume,
     V1VolumeMount,
 )
@@ -19,6 +26,8 @@ from ..config import (
     PVCVolumeSource,
 )
 from ..models.domain.lab import LabVolumeContainer
+from ..models.domain.rspimage import RSPImage
+from ..storage.metadata import MetadataStorage
 
 __all__ = ["LabBuilder"]
 
@@ -170,3 +179,85 @@ class LabBuilder:
             )
             vols.append(LabVolumeContainer(volume=vol, volume_mount=vm))
         return vols
+
+
+class PrepullerBuilder:
+    """Construct Kubernetes objects used by the prepuller.
+
+    Parameters
+    ----------
+    metadata_storage
+        Storage layer for pod metadata about the lab controller itself.
+    pull_secret
+        Optional name of ``Secret`` object to use for pulling images.
+    """
+
+    def __init__(
+        self, metadata_storage: MetadataStorage, pull_secret: str | None = None
+    ) -> None:
+        self._metadata = metadata_storage
+        self._pull_secret = pull_secret
+
+    def build_pod(self, image: RSPImage, node: str) -> V1Pod:
+        """Construct the pod object for a prepuller pod.
+
+        Parameters
+        ----------
+        image
+            Image to prepull.
+        node
+            Node on which to prepull it.
+
+        Returns
+        -------
+        kubernetes_asyncio.client.V1Pod
+            Kubernetes ``Pod`` object to create.
+        """
+        pull_secrets = []
+        if self._pull_secret:
+            pull_secrets.append(V1LocalObjectReference(name=self._pull_secret))
+        return V1Pod(
+            metadata=V1ObjectMeta(
+                name=self._build_pod_name(image, node),
+                labels={"nublado.lsst.io/category": "prepuller"},
+                owner_references=[self._metadata.owner_reference],
+            ),
+            spec=V1PodSpec(
+                containers=[
+                    V1Container(
+                        name="prepull",
+                        command=["/bin/sleep", "5"],
+                        image=image.reference_with_digest,
+                        working_dir="/tmp",
+                    )
+                ],
+                image_pull_secrets=pull_secrets if pull_secrets else None,
+                node_name=node,
+                restart_policy="Never",
+            ),
+        )
+
+    def _build_pod_name(self, image: RSPImage, node: str) -> str:
+        """Create the pod name to use for prepulling an image.
+
+        This embeds some information in the pod name that may be useful for
+        debugging purposes.
+
+        Parameters
+        ----------
+        image
+            Image to prepull.
+        node
+            Node on which to prepull it.
+
+        Returns
+        -------
+        str
+            Pod name to use.
+        """
+        tag_part = image.tag.replace("_", "-")
+        tag_part = re.sub(r"[^\w.-]", "", tag_part, flags=re.ASCII)
+        name = f"prepull-{tag_part}-{node}"
+
+        # Kubernetes object names may be at most 253 characters long.
+        return name[:253]

--- a/src/jupyterlabcontroller/storage/k8s.py
+++ b/src/jupyterlabcontroller/storage/k8s.py
@@ -675,9 +675,6 @@ class K8sStorageClient:
     # Prepuller methods
     #
 
-    async def remove_completed_pod(self, podname: str, namespace: str) -> None:
-        await self._pod.delete_after_completion(podname, namespace)
-
     async def get_image_data(self) -> dict[str, list[KubernetesNodeImage]]:
         """Get the list of cached images from each node.
 

--- a/src/jupyterlabcontroller/storage/metadata.py
+++ b/src/jupyterlabcontroller/storage/metadata.py
@@ -1,0 +1,55 @@
+"""Storage layer for pod metadata."""
+
+from __future__ import annotations
+
+from functools import cached_property
+from pathlib import Path
+
+from kubernetes_asyncio.client import V1OwnerReference
+
+__all__ = ["MetadataStorage"]
+
+
+class MetadataStorage:
+    """Storage layer for pod metadata for the running pod.
+
+    Some attributes of the Kubernetes objects created by the lab controller
+    depend on metadata about where the lab controller is running. This storage
+    layer retrieves that information via the Kubernetes `downward API`_.
+
+    Parameters
+    ----------
+    metadata_path
+        Path at which the downward API data is mounted.
+    """
+
+    def __init__(self, metadata_path: Path) -> None:
+        self._path = metadata_path
+
+    @cached_property
+    def namespace(self) -> str:
+        """The namespace in which the lab controller is running.
+
+        Some resources, such as prepuller pods, are spawned in the same
+        namespace as the lab controller.
+        """
+        return (self._path / "namespace").read_text().strip()
+
+    @cached_property
+    def owner_reference(self) -> V1OwnerReference:
+        """An owner reference pointing to the lab controller.
+
+        We want some objects, such as prepuller pods, to show as owned by the
+        lab controller. This enables clearer display in services such as Argo
+        CD and also hopefully tells Kubernetes to delete the pods when the lab
+        controller is deleted, avoiding later conflicts.
+        """
+        name_path = self._path / "name"
+        uid_path = self._path / "uid"
+        return V1OwnerReference(
+            api_version="v1",
+            kind="Pod",
+            name=name_path.read_text().strip(),
+            uid=uid_path.read_text().strip(),
+            block_owner_deletion=True,
+        )

--- a/tests/configs/gar/input/metadata/name
+++ b/tests/configs/gar/input/metadata/name
@@ -1,0 +1,1 @@
+nublado-controller

--- a/tests/configs/gar/input/metadata/namespace
+++ b/tests/configs/gar/input/metadata/namespace
@@ -1,0 +1,1 @@
+nublado

--- a/tests/configs/gar/input/metadata/uid
+++ b/tests/configs/gar/input/metadata/uid
@@ -1,0 +1,1 @@
+12720beb-ecae-452e-982e-2f0a0a2fbaf1

--- a/tests/configs/standard/input/metadata/namespace
+++ b/tests/configs/standard/input/metadata/namespace
@@ -1,0 +1,1 @@
+nublado

--- a/tests/configs/standard/output/prepull-conflict-objects.json
+++ b/tests/configs/standard/output/prepull-conflict-objects.json
@@ -3,15 +3,11 @@
     "api_version": "v1",
     "kind": "Pod",
     "metadata": {
-      "annotations": {
-        "argocd.argoproj.io/compare-options": "IgnoreExtraneous",
-        "argocd.argoproj.io/sync-options": "Prune=false"
-      },
       "labels": {
 	"nublado.lsst.io/category": "prepuller"
       },
       "name": "prepull-d-2077-10-23-node2",
-      "namespace": "userlabs",
+      "namespace": "nublado",
       "owner_references": [
         {
           "api_version": "v1",

--- a/tests/configs/standard/output/prepull-objects.json
+++ b/tests/configs/standard/output/prepull-objects.json
@@ -3,15 +3,11 @@
     "api_version": "v1",
     "kind": "Pod",
     "metadata": {
-      "annotations": {
-        "argocd.argoproj.io/compare-options": "IgnoreExtraneous",
-        "argocd.argoproj.io/sync-options": "Prune=false"
-      },
       "labels": {
 	"nublado.lsst.io/category": "prepuller"
       },
       "name": "prepull-d-2077-10-23-node2",
-      "namespace": "userlabs",
+      "namespace": "nublado",
       "owner_references": [
         {
           "api_version": "v1",


### PR DESCRIPTION
Model the new separation between builder objects, services, and the Kubernetes storage layer with the prepuller, which is the simplest. Add a new PrepullerBuilder that constructs the pod that the prepuller uses, and have it use that and the PodStorage storage layer directly, so it no longer needs K8sStorageClient.

Introduce a new MetadataStorage layer, which is resposible for getting metadata about the running pod from the Kubernetes downward API, and use it for namespace and object reference information for the prepuller pods.

Stop using the namespace prefix for labs as the namespace for prepuller pods and always use the namespace from the downward API. Make the downward API information mandatory; there's really no reason not to have it.

Stop adding Argo CD annotations to the prepuller pods. Since they are children of the controller pod, they don't need any.