### PR TITLE
DM-40813: Move Argo CD annotations into a constant

### DIFF
--- a/src/jupyterlabcontroller/constants.py
+++ b/src/jupyterlabcontroller/constants.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from pathlib import Path
 
 __all__ = [
+    "ARGO_CD_ANNOTATIONS",
     "CONFIGURATION_PATH",
     "DOCKER_SECRETS_PATH",
     "DROPDOWN_SENTINEL_VALUE",
@@ -18,6 +19,18 @@ __all__ = [
     "SPAWNER_FORM_TEMPLATE",
     "USERNAME_REGEX",
 ]
+
+ARGO_CD_ANNOTATIONS = {
+    "argocd.argoproj.io/compare-options": "IgnoreExtraneous",
+    "argocd.argoproj.io/sync-options": "Prune=false",
+}
+"""Annotations to add to most created objects.
+
+These annotations tell Argo CD to ignore these resources for the purposes of
+determining if the Argo Cd ``Application`` object is out of date. We apply
+them to all the resources managed by the Nublado controller, since Argo CD
+should not manage them.
+"""
 
 CONFIGURATION_PATH = Path("/etc/nublado/config.yaml")
 """Default path to controller configuration."""

--- a/src/jupyterlabcontroller/storage/k8s.py
+++ b/src/jupyterlabcontroller/storage/k8s.py
@@ -34,6 +34,7 @@ from kubernetes_asyncio.client import (
 from structlog.stdlib import BoundLogger
 
 from ..config import LabSecret
+from ..constants import ARGO_CD_ANNOTATIONS
 from ..exceptions import (
     DuplicateObjectError,
     KubernetesError,
@@ -287,10 +288,7 @@ class K8sStorageClient:
             labels["argocd.argoproj.io/instance"] = argo_app
         if username:
             labels["nublado.lsst.io/user"] = username
-        annotations = {
-            "argocd.argoproj.io/compare-options": "IgnoreExtraneous",
-            "argocd.argoproj.io/sync-options": "Prune=false",
-        }
+        annotations = ARGO_CD_ANNOTATIONS.copy()
         metadata = V1ObjectMeta(
             name=name,
             labels=labels,


### PR DESCRIPTION
Pull the default Argo CD annotations for lab and file server objects out of the storage layer and into a constant.