### PR TITLE
DM-40813: Automatically reconfigure running test apps

### DIFF
--- a/src/jupyterlabcontroller/dependencies/context.py
+++ b/src/jupyterlabcontroller/dependencies/context.py
@@ -89,6 +89,11 @@ class ContextDependency:
             fileserver_state=self._process_context.fileserver_state,
         )
 
+    @property
+    def is_initialized(self) -> bool:
+        """Whether the process context has been initialized."""
+        return self._process_context is not None
+
     async def initialize(self, config: Config) -> None:
         """Initialize the process-global shared context.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,10 +44,10 @@ def obj_factory(std_config_dir: Path) -> TestObjectFactory:
     return test_object_factory
 
 
-@pytest.fixture
-def config() -> Config:
+@pytest_asyncio.fixture
+async def config() -> Config:
     """Construct default configuration for tests."""
-    return configure("standard")
+    return await configure("standard")
 
 
 @pytest_asyncio.fixture

--- a/tests/fileserver/conftest.py
+++ b/tests/fileserver/conftest.py
@@ -52,7 +52,7 @@ def obj_factory(std_config_dir: Path) -> TestObjectFactory:
 @pytest_asyncio.fixture
 async def config() -> Config:
     """Construct default configuration for tests."""
-    return configure("fileserver")
+    return await configure("fileserver")
 
 
 @pytest_asyncio.fixture

--- a/tests/handlers/extra_annotations_test.py
+++ b/tests/handlers/extra_annotations_test.py
@@ -2,8 +2,6 @@ import pytest
 from httpx import AsyncClient
 from safir.testing.kubernetes import MockKubernetesApi
 
-from jupyterlabcontroller.dependencies.context import context_dependency
-
 from ..settings import TestObjectFactory
 from ..support.config import configure
 
@@ -15,13 +13,9 @@ async def test_extra_annotations(
     obj_factory: TestObjectFactory,
 ) -> None:
     """Check that the pod picks up extra annotations set in the config."""
+    config = await configure("extra-annotations")
     token, user = obj_factory.get_user()
     lab = obj_factory.labspecs[0]
-
-    # Reconfigure the app to add annotations
-    await context_dependency.aclose()
-    config = configure("extra-annotations")
-    await context_dependency.initialize(config)
 
     r = await client.post(
         f"/nublado/spawner/v1/labs/{user.username}/create",

--- a/tests/handlers/labs_test.py
+++ b/tests/handlers/labs_test.py
@@ -22,7 +22,6 @@ from safir.testing.slack import MockSlackWebhook
 
 from jupyterlabcontroller.config import Config
 from jupyterlabcontroller.constants import DROPDOWN_SENTINEL_VALUE
-from jupyterlabcontroller.dependencies.context import context_dependency
 from jupyterlabcontroller.factory import Factory
 from jupyterlabcontroller.models.domain.kubernetes import PodPhase
 
@@ -702,13 +701,9 @@ async def test_homedir_schema(
     was always :file:`/home/{username}` even if another home directory rule
     was set.
     """
+    config = await configure("homedir-schema")
     token, user = obj_factory.get_user()
     lab = obj_factory.labspecs[0]
-
-    # Reconfigure the app to use a different home directory scheme.
-    await context_dependency.aclose()
-    config = configure("homedir-schema")
-    await context_dependency.initialize(config)
 
     r = await client.post(
         f"/nublado/spawner/v1/labs/{user.username}/create",

--- a/tests/handlers/volume_cases_test.py
+++ b/tests/handlers/volume_cases_test.py
@@ -2,8 +2,6 @@ import pytest
 from httpx import AsyncClient
 from safir.testing.kubernetes import MockKubernetesApi
 
-from jupyterlabcontroller.dependencies.context import context_dependency
-
 from ..settings import TestObjectFactory
 from ..support.config import configure
 
@@ -15,13 +13,9 @@ async def test_volume_cases(
     obj_factory: TestObjectFactory,
 ) -> None:
     """Check that the pod picks up extra annotations set in the config."""
+    config = await configure("volume-cases")
     token, user = obj_factory.get_user()
     lab = obj_factory.labspecs[0]
-
-    # Reconfigure the app to add annotations
-    await context_dependency.aclose()
-    config = configure("volume-cases")
-    await context_dependency.initialize(config)
 
     r = await client.post(
         f"/nublado/spawner/v1/labs/{user.username}/create",

--- a/tests/services/prepuller_test.py
+++ b/tests/services/prepuller_test.py
@@ -122,7 +122,7 @@ async def test_gar(
     mock_gar: MockArtifactRegistry, mock_kubernetes: MockKubernetesApi
 ) -> None:
     """Test the prepuller service configured to talk to GAR."""
-    config = configure("gar")
+    config = await configure("gar")
     assert isinstance(config.images.source, GARSourceConfig)
     known_images = read_input_json("gar", "known-images.json")
     for known_image in known_images:
@@ -202,7 +202,7 @@ async def test_cycle(
     mock_docker: MockDockerRegistry,
     mock_kubernetes: MockKubernetesApi,
 ) -> None:
-    config = configure("cycle")
+    config = await configure("cycle")
     mock_docker.tags = read_input_json("cycle", "docker-tags.json")
     node_data = read_input_json("cycle", "nodes.json")
     nodes = []
@@ -241,7 +241,7 @@ async def test_gar_cycle(
     mock_gar: MockArtifactRegistry,
     mock_kubernetes: MockKubernetesApi,
 ) -> None:
-    config = configure("gar-cycle")
+    config = await configure("gar-cycle")
     known_images = read_input_json("gar-cycle", "known-images.json")
     for known_image in known_images:
         image = DockerImage(**known_image)

--- a/tests/support/config.py
+++ b/tests/support/config.py
@@ -6,12 +6,16 @@ from pathlib import Path
 
 from jupyterlabcontroller.config import Config
 from jupyterlabcontroller.dependencies.config import configuration_dependency
+from jupyterlabcontroller.dependencies.context import context_dependency
 
 __all__ = ["configure"]
 
 
-def configure(directory: str) -> Config:
-    """Generate test configuration.
+async def configure(directory: str) -> Config:
+    """Configure or reconfigure with a test configuration.
+
+    If the global process context was already initialized, stop the background
+    processes and restart them with the new configuration.
 
     Parameters
     ----------
@@ -27,7 +31,19 @@ def configure(directory: str) -> Config:
     config_path = base_path / directory / "input"
     configuration_dependency.set_path(config_path / "config.yaml")
     config = configuration_dependency.config
+
+    # Adjust the configuration to point to external objects if they're present
+    # in the configuration directory.
     if (config_path / "docker_config.json").exists():
         config.docker_secrets_path = config_path / "docker_config.json"
     config.metadata_path = config_path / "metadata"
+
+    # If the process context was initialized, meaning that we already have
+    # running background processes with the old configuration, stop and
+    # restart them with the new configuration.
+    if context_dependency.is_initialized:
+        await context_dependency.aclose()
+        await context_dependency.initialize(config)
+
+    # Return the new configuration.
     return configuration_dependency.config


### PR DESCRIPTION
If a test version of the controller is running and a test case calls configure, automatically reset the process context to use the new configuration.