### PR TITLE
DM-40813: Move fileserver object creation into a builder

### DIFF
--- a/src/jupyterlabcontroller/config.py
+++ b/src/jupyterlabcontroller/config.py
@@ -387,6 +387,13 @@ class FileserverConfig(CamelCaseModel):
     creation_timeout: int = Field(
         120, title="Timeout for fileserver creation (seconds)"
     )
+    application: str | None = Field(
+        None,
+        title="Argo CD application",
+        description=(
+            "An Argo CD application under which fileservers should be shown"
+        ),
+    )
 
     # Only care if our fields are filled out if the fileserver is enabled.
     # Doing it this way saves a lot of assertions about when values

--- a/src/jupyterlabcontroller/models/domain/fileserver.py
+++ b/src/jupyterlabcontroller/models/domain/fileserver.py
@@ -1,8 +1,29 @@
 """Models for the fileserver state."""
 
 import contextlib
+from dataclasses import dataclass
+from typing import Any
 
-__all__ = ["FileserverUserMap"]
+from kubernetes_asyncio.client import V1Job, V1Service
+
+__all__ = [
+    "FileserverObjects",
+    "FileserverUserMap",
+]
+
+
+@dataclass
+class FileserverObjects:
+    """All of the Kubernetes objects making up a user's fileserver."""
+
+    ingress: dict[str, Any]
+    """``GafaelfawrIngress`` object for the fileserver."""
+
+    service: V1Service
+    """Service for reaching the fileserver."""
+
+    job: V1Job
+    """Job that runs the fileserver itself."""
 
 
 class FileserverUserMap:

--- a/src/jupyterlabcontroller/models/domain/lab.py
+++ b/src/jupyterlabcontroller/models/domain/lab.py
@@ -14,8 +14,6 @@ from kubernetes_asyncio.client.models import (
     V1ResourceQuota,
     V1Secret,
     V1Service,
-    V1Volume,
-    V1VolumeMount,
 )
 from safir.asyncio import AsyncMultiQueue
 
@@ -24,7 +22,6 @@ from ..v1.lab import UserLabState
 
 __all__ = [
     "LabObjects",
-    "LabVolumeContainer",
     "UserLab",
 ]
 
@@ -56,12 +53,6 @@ class LabObjects:
 
     pod: V1Pod
     """User's lab pod."""
-
-
-@dataclass
-class LabVolumeContainer:
-    volume: V1Volume
-    volume_mount: V1VolumeMount
 
 
 @dataclass

--- a/src/jupyterlabcontroller/models/domain/volumes.py
+++ b/src/jupyterlabcontroller/models/domain/volumes.py
@@ -1,0 +1,25 @@
+"""Models for mounted volumes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from kubernetes_asyncio.client import V1Volume, V1VolumeMount
+
+__all__ = ["MountedVolume"]
+
+
+@dataclass
+class MountedVolume:
+    """Represents a volume along with its corresponding mount.
+
+    It's often more convenient to construct its volume (which is defined at
+    the pod level) and its mount point (defined at the container level)
+    together and only separate them when constructing Kubernetes objects.
+    """
+
+    volume: V1Volume
+    """Kubernetes volume definition."""
+
+    volume_mount: V1VolumeMount
+    """Mount definiton for that volume within a container."""

--- a/src/jupyterlabcontroller/services/builder/fileserver.py
+++ b/src/jupyterlabcontroller/services/builder/fileserver.py
@@ -1,0 +1,210 @@
+"""Construction of Kubernetes objects for user fileservers."""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import urlparse
+
+from kubernetes_asyncio.client import (
+    V1Container,
+    V1ContainerPort,
+    V1EnvVar,
+    V1Job,
+    V1JobSpec,
+    V1ObjectMeta,
+    V1PodSecurityContext,
+    V1PodSpec,
+    V1PodTemplateSpec,
+    V1SecurityContext,
+    V1Service,
+    V1ServicePort,
+    V1ServiceSpec,
+)
+
+from ...config import FileserverConfig, LabVolume
+from ...constants import ARGO_CD_ANNOTATIONS
+from ...models.domain.fileserver import FileserverObjects
+from ...models.v1.lab import UserInfo
+from .volumes import VolumeBuilder
+
+__all__ = ["FileserverBuilder"]
+
+
+class FileserverBuilder:
+    """Construct Kubernetes objects for user fileservers.
+
+    Parameters
+    ----------
+    config
+        Fileserver configuration.
+    instance_url
+        Base URL for this Notebook Aspect instance.
+    volumes
+        Volumes to mount in the user's fileserver.
+    """
+
+    def __init__(
+        self,
+        config: FileserverConfig,
+        instance_url: str,
+        volumes: list[LabVolume],
+    ) -> None:
+        self._config = config
+        self._instance_url = instance_url
+        self._volumes = volumes
+        self._volume_builder = VolumeBuilder()
+
+    def build_fileserver(self, user: UserInfo) -> FileserverObjects:
+        """Construct the objects that make up a user's fileserver.
+
+        Parameters
+        ----------
+        user
+            User for whom to create a fileserver.
+
+        Returns
+        -------
+        FileserverObjects
+            Kubernetes objects for the fileserver.
+        """
+        return FileserverObjects(
+            ingress=self._build_fileserver_ingress(user.username),
+            service=self._build_fileserver_service(user.username),
+            job=self._build_fileserver_job(user),
+        )
+
+    def build_fileserver_name(self, username: str) -> str:
+        """Construct the name of fileserver objects.
+
+        Parameters
+        ----------
+        username
+            Username the fileserver is for.
+
+        Returns
+        -------
+        str
+            Name of all Kubernetes objects for that fileserver.
+        """
+        return f"{username}-fs"
+
+    def _build_metadata(self, username: str) -> V1ObjectMeta:
+        """Construct the metadata for an object.
+
+        This adds some standard labels and annotations providing Nublado
+        metadata and telling Argo CD how to handle this object.
+        """
+        name = self.build_fileserver_name(username)
+        labels = {
+            "nublado.lsst.io/category": "fileserver",
+            "nublado.lsst.io/user": username,
+        }
+        if self._config.application:
+            labels["argocd.argoproj.io/instance"] = self._config.application
+        annotations = ARGO_CD_ANNOTATIONS.copy()
+        return V1ObjectMeta(name=name, labels=labels, annotations=annotations)
+
+    def _build_fileserver_ingress(self, username: str) -> dict[str, Any]:
+        """Construct ``GafaelfawrIngress`` object for the fileserver."""
+        host = urlparse(self._instance_url).hostname
+        metadata = self._build_metadata(username).to_dict(serialize=True)
+        path = {
+            "path": f"/files/{username}",
+            "pathType": "Prefix",
+            "backend": {
+                "service": {
+                    "name": self.build_fileserver_name(username),
+                    "port": {"number": 8000},
+                }
+            },
+        }
+        return {
+            "apiVersion": "gafaelfawr.lsst.io/v1alpha1",
+            "kind": "GafaelfawrIngress",
+            "metadata": metadata,
+            "config": {
+                "baseUrl": self._instance_url,
+                "scopes": {"all": ["exec:notebook"]},
+                "loginRedirect": False,
+                "authType": "basic",
+            },
+            "template": {
+                "metadata": {
+                    "name": metadata["name"],
+                    "labels": {
+                        "nublado.lsst.io/category": "fileserver",
+                        "nublado.lsst.io/user": username,
+                    },
+                },
+                "spec": {"rules": [{"host": host, "http": {"paths": [path]}}]},
+            },
+        }
+
+    def _build_fileserver_job(self, user: UserInfo) -> V1Job:
+        """Construct the job for a fileserver."""
+        volume_data = self._volume_builder.build_mounted_volumes(
+            user.username, self._volumes, prefix="/mnt"
+        )
+        url = f"{self._config.path_prefix}/files/{user.username}"
+        resources = self._config.resources
+        timeout = str(self._config.timeout)
+
+        # Specification for the user's container.
+        container = V1Container(
+            name="fileserver",
+            env=[
+                V1EnvVar(name="WORBLEHAT_BASE_HREF", value=url),
+                V1EnvVar(name="WORBLEHAT_TIMEOUT", value=timeout),
+                V1EnvVar(name="WORBLEHAT_DIR", value="/mnt"),
+            ],
+            image=f"{self._config.image}:{self._config.tag}",
+            image_pull_policy=self._config.pull_policy.value,
+            ports=[V1ContainerPort(container_port=8000, name="http")],
+            resources=resources.to_kubernetes() if resources else None,
+            security_context=V1SecurityContext(
+                allow_privilege_escalation=False,
+                read_only_root_filesystem=True,
+            ),
+            volume_mounts=[v.volume_mount for v in volume_data],
+        )
+
+        # Build the pod specification itself.
+        metadata = self._build_metadata(user.username)
+        return V1Job(
+            metadata=metadata,
+            spec=V1JobSpec(
+                template=V1PodTemplateSpec(
+                    metadata=V1ObjectMeta(
+                        name=metadata.name,
+                        labels={
+                            "nublado.lsst.io/category": "fileserver",
+                            "nublado.lsst.io/user": user.username,
+                        },
+                    ),
+                    spec=V1PodSpec(
+                        containers=[container],
+                        restart_policy="Never",
+                        security_context=V1PodSecurityContext(
+                            run_as_user=user.uid,
+                            run_as_group=user.gid,
+                            run_as_non_root=True,
+                            supplemental_groups=[x.id for x in user.groups],
+                        ),
+                        volumes=[v.volume for v in volume_data],
+                    ),
+                )
+            ),
+        )
+
+    def _build_fileserver_service(self, username: str) -> V1Service:
+        """Construct the service for a fileserver."""
+        return V1Service(
+            metadata=self._build_metadata(username),
+            spec=V1ServiceSpec(
+                ports=[V1ServicePort(port=8000, target_port=8000)],
+                selector={
+                    "nublado.lsst.io/category": "fileserver",
+                    "nublado.lsst.io/user": username,
+                },
+            ),
+        )

--- a/src/jupyterlabcontroller/services/builder/volumes.py
+++ b/src/jupyterlabcontroller/services/builder/volumes.py
@@ -1,0 +1,132 @@
+"""Construction of Kubernetes objects for volumes and volume mounts."""
+
+from __future__ import annotations
+
+from kubernetes_asyncio.client import (
+    V1HostPathVolumeSource,
+    V1NFSVolumeSource,
+    V1PersistentVolumeClaimVolumeSource,
+    V1Volume,
+    V1VolumeMount,
+)
+
+from ...config import (
+    FileMode,
+    HostPathVolumeSource,
+    LabVolume,
+    NFSVolumeSource,
+    PVCVolumeSource,
+)
+from ...models.domain.volumes import MountedVolume
+
+__all__ = ["VolumeBuilder"]
+
+
+class VolumeBuilder:
+    """Construct Kubernetes objects for volumes and volume mounts.
+
+    This is broken into its own class since it is used when constructing both
+    labs and fileservers.
+    """
+
+    def build_mounted_volumes(
+        self, username: str, volumes: list[LabVolume], prefix: str = ""
+    ) -> list[MountedVolume]:
+        """Construct volumes and mounts for volumes in the lab configuration.
+
+        Parameters
+        ----------
+        username
+            Name of user this lab is for, used to name the PVC objects.
+        volumes
+            Configured volumes.
+        prefix
+            Prefix to prepend to all mount paths, if given.
+
+        Returns
+        -------
+        list of MountedVolume
+            List of volumes and mounts.
+        """
+        volume_objects = self._build_volumes(username, volumes)
+        mounts = self._build_mounts(volumes, prefix)
+        return [
+            MountedVolume(volume=v, volume_mount=m)
+            for v, m in zip(volume_objects, mounts, strict=True)
+        ]
+
+    def _build_volume_name(self, volume: LabVolume) -> str:
+        """Construct the name of the volume resource."""
+        return volume.container_path.replace("/", "-")[1:].lower()
+
+    def _build_volumes(
+        self, username: str, volumes: list[LabVolume]
+    ) -> list[V1Volume]:
+        """Construct volumes and mounts for volumes in the lab configuration.
+
+        Parameters
+        ----------
+        username
+            Name of user this lab is for, used to name the PVC objects.
+        volumes
+            Configured volumes.
+
+        Returns
+        -------
+        list of kubernetes_asyncio.client.V1Volume
+            List of volumes and mounts.
+        """
+        results = []
+        pvc_count = 1
+        for spec in volumes:
+            is_readonly = spec.mode == FileMode.RO
+            name = self._build_volume_name(spec)
+            match spec.source:
+                case HostPathVolumeSource() as source:
+                    host_path = V1HostPathVolumeSource(path=source.path)
+                    volume = V1Volume(name=name, host_path=host_path)
+                case NFSVolumeSource() as source:
+                    volume = V1Volume(
+                        name=name,
+                        nfs=V1NFSVolumeSource(
+                            path=source.server_path,
+                            read_only=is_readonly,
+                            server=source.server,
+                        ),
+                    )
+                case PVCVolumeSource():
+                    claim = V1PersistentVolumeClaimVolumeSource(
+                        claim_name=f"{username}-nb-pvc-{pvc_count}",
+                        read_only=is_readonly,
+                    )
+                    volume = V1Volume(name=name, persistent_volume_claim=claim)
+                    pvc_count += 1
+            results.append(volume)
+        return results
+
+    def _build_mounts(
+        self, volumes: list[LabVolume], prefix: str = ""
+    ) -> list[V1VolumeMount]:
+        """Construct volume mounts for configured volumes.
+
+        Parameters
+        ----------
+        volumes
+            Configured volumes.
+        prefix
+            Prefix to prepend to all mount paths, if given.
+
+        Returns
+        -------
+        list of kubernetes_asyncio.client.V1VolumeMount
+            List of volumes and mounts.
+        """
+        return [
+            V1VolumeMount(
+                name=self._build_volume_name(v),
+                mount_path=prefix + v.container_path,
+                sub_path=v.sub_path,
+                read_only=v.mode == FileMode.RO,
+            )
+            for v in volumes
+        ]

--- a/src/jupyterlabcontroller/services/lab.py
+++ b/src/jupyterlabcontroller/services/lab.py
@@ -179,7 +179,7 @@ class LabManager:
 
         # Create the lab objects in Kubernetes.
         self._logger.info("Creating new lab")
-        await self._storage.create_lab(objects)
+        await self._storage.create(objects)
         await self._lab_state.publish_pod_creation(
             username, "Created Kubernetes objects for user lab", 30
         )

--- a/src/jupyterlabcontroller/storage/kubernetes/fileserver.py
+++ b/src/jupyterlabcontroller/storage/kubernetes/fileserver.py
@@ -1,0 +1,179 @@
+"""Kubernetes storage layer for user fileservers."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from kubernetes_asyncio.client import ApiClient, V1Pod
+from safir.datetime import current_datetime
+from structlog.stdlib import BoundLogger
+
+from ...exceptions import DuplicateObjectError, MissingObjectError
+from ...models.domain.fileserver import FileserverObjects
+from ...models.domain.kubernetes import PodPhase
+from .custom import GafaelfawrIngressStorage
+from .deleter import JobStorage, ServiceStorage
+from .ingress import IngressStorage
+from .pod import PodStorage
+
+__all__ = ["FileserverStorage"]
+
+
+class FileserverStorage:
+    """Kubernetes storage layer for fileservers.
+
+    Parameters
+    ----------
+    api_client
+        Kubernetes API client.
+    logger
+        Logger to use.
+
+    Notes
+    -----
+    This class isn't strictly necessary; instead, the fileserver service could
+    call the storage layers for individual Kubernetes objects directly. But
+    there are enough different objects in play that adding a thin layer to
+    wrangle the storage objects makes the fileserver service easier to follow.
+    """
+
+    def __init__(self, api_client: ApiClient, logger: BoundLogger) -> None:
+        self._logger = logger
+        self._gafaelfawr = GafaelfawrIngressStorage(api_client, logger)
+        self._ingress = IngressStorage(api_client, logger)
+        self._job = JobStorage(api_client, logger)
+        self._service = ServiceStorage(api_client, logger)
+        self._pod = PodStorage(api_client, logger)
+
+    async def create(
+        self, namespace: str, objects: FileserverObjects, timeout: timedelta
+    ) -> None:
+        """Create all of the Kubernetes objects for a fileserver.
+
+        Create the objects in Kubernetes and then wait for the fileserver pod
+        to start and for the ingress to be ready.
+
+        Parameters
+        ----------
+        namespace
+            Namespace where the objects should live.
+        objects
+            Kubernetes objects making up the fileserver.
+        timeout
+            How long to wait for the fileserver to start.
+
+        Raises
+        ------
+        DuplicateObjectError
+            Raised if multiple pods were found for the fileserver job.
+        KubernetesError
+            Raised if there is some failure in a Kubernetes API call.
+        MissingObjectError
+            Raised if no pod was created for the fileserver job.
+        TimeoutError
+            Raised if the fileserver takes longer than the provided timeout to
+            create or start.
+        """
+        start = current_datetime(microseconds=True)
+        await self._gafaelfawr.create(namespace, objects.ingress)
+        await self._service.create(namespace, objects.service)
+        await self._job.create(namespace, objects.job)
+
+        # Wait for the pod to start.
+        pod = await self._get_pod_for_job(objects.job.metadata.name, namespace)
+        timeout_left = timeout - (current_datetime(microseconds=True) - start)
+        if timeout_left <= timedelta(seconds=0):
+            raise TimeoutError
+        await self._pod.wait_for_phase(
+            pod.metadata.name,
+            namespace,
+            until_not={PodPhase.UNKNOWN, PodPhase.PENDING},
+            timeout=timeout_left,
+        )
+
+        # Wait for the ingress to get an IP address assigned. This usually
+        # takes the longest.
+        name = objects.ingress["metadata"]["name"]
+        timeout_left = timeout - (current_datetime(microseconds=True) - start)
+        if timeout_left <= timedelta(seconds=0):
+            raise TimeoutError
+        await self._ingress.wait_for_ip_address(name, namespace, timeout_left)
+
+    async def delete(self, name: str, namespace: str) -> None:
+        """Delete a fileserver.
+
+        Parameters
+        ----------
+        name
+            Name of the filesever objects.
+        namespace
+            Namespace in which fileservers run.
+
+        Raises
+        ------
+        KubernetesError
+            Raised if there is some failure in a Kubernetes API call.
+        """
+        await self._gafaelfawr.delete(name, namespace, wait=True)
+        await self._ingress.wait_for_deletion(name, namespace)
+        await self._service.delete(name, namespace)
+        await self._job.delete(name, namespace, wait=True)
+
+    async def wait_for_pod_exit(self, name: str, namespace: str) -> None:
+        """Wait for the fileserver pod spawned by the job to exit.
+
+        Parameters
+        ----------
+        name
+            Name of the fileserver job.
+        namespace
+            Namespace in which fileservers run.
+
+        Raises
+        ------
+        KubernetesError
+            Raised if there is some failure in a Kubernetes API call.
+        """
+        pod = await self._get_pod_for_job(name, namespace)
+        await self._pod.wait_for_phase(
+            pod.metadata.name,
+            namespace,
+            until_not={PodPhase.UNKNOWN, PodPhase.PENDING, PodPhase.RUNNING},
+        )
+
+    async def _get_pod_for_job(self, name: str, namespace: str) -> V1Pod:
+        """Get the ``Pod`` corresponding to a ``Job``.
+
+        Parameters
+        ----------
+        name
+            Name of the job.
+        namespace
+            Namespace in which to search.
+
+        Returns
+        -------
+        kubernetes_asyncio.client.V1Pod
+            Corresponding pod.
+
+        Raises
+        ------
+        DuplicateObjectError
+            Raised if multiple pods were found for the fileserver job.
+        KubernetesError
+            Raised if there is some failure in a Kubernetes API call.
+        MissingObjectError
+            Raised if no pod was created for the fileserver job.
+        """
+        selector = f"job-name={name}"
+        pods = await self._pod.list(namespace, label_selector=selector)
+        if not pods:
+            raise MissingObjectError(
+                message=f"Pod for fileserver job {name} not found",
+                namespace=namespace,
+                kind="Pod",
+            )
+        if len(pods) > 1:
+            msg = f"Multiple pods match job {name}"
+            raise DuplicateObjectError(msg, kind="Pod", namespace=namespace)
+        return pods[0]

--- a/src/jupyterlabcontroller/storage/kubernetes/lab.py
+++ b/src/jupyterlabcontroller/storage/kubernetes/lab.py
@@ -51,7 +51,7 @@ class LabStorage:
         self._secret = SecretStorage(api_client, logger)
         self._service = ServiceStorage(api_client, logger)
 
-    async def create_lab(self, objects: LabObjects) -> None:
+    async def create(self, objects: LabObjects) -> None:
         """Create all of the Kubernetes objects for a user's lab.
 
         Parameters

--- a/src/jupyterlabcontroller/storage/kubernetes/pod.py
+++ b/src/jupyterlabcontroller/storage/kubernetes/pod.py
@@ -131,7 +131,7 @@ class PodStorage(KubernetesObjectDeleter):
         until_not: set[PodPhase],
         timeout: timedelta | None = None,
     ) -> PodPhase | None:
-        """Waits for a pod to finish starting.
+        """Waits for a pod to exit a set of phases.
 
         Waits for the pod to reach a phase other than the ones given, and
         returns the new phase.
@@ -146,7 +146,7 @@ class PodStorage(KubernetesObjectDeleter):
             Wait until the pod is not in one of these phases (or was deleted,
             or the watch timed out).
         timeout
-            Timeout to wait for the pod to start.
+            Timeout to wait for the pod to enter another phase.
 
         Returns
         -------

--- a/src/jupyterlabcontroller/storage/kubernetes/watcher.py
+++ b/src/jupyterlabcontroller/storage/kubernetes/watcher.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass
 from datetime import timedelta
@@ -157,8 +158,11 @@ class KubernetesWatcher(Generic[T]):
         if resource_version:
             args["resource_version"] = resource_version
         if timeout:
-            args["timeout_seconds"] = int(timeout.total_seconds())
-            args["_request_timeout"] = int(timeout.total_seconds())
+            timeout_seconds = int(math.ceil(timeout.total_seconds()))
+            if timeout_seconds <= 0:
+                raise ValueError("Watch timeout specified but <= 0")
+            args["timeout_seconds"] = timeout_seconds
+            args["_request_timeout"] = timeout_seconds
         self._args = args
 
         # Passing in an explicit type should not be necessary, but the

--- a/tests/configs/fileserver/input/config.yaml
+++ b/tests/configs/fileserver/input/config.yaml
@@ -42,4 +42,4 @@ fileserver:
   creationTimeout: 1
   namespace: fileservers
   image: ghcr.io/lsst-sqre/worblehat
-
+  application: fileservers

--- a/tests/fileserver/handlers/object_cleanup_on_exit_test.py
+++ b/tests/fileserver/handlers/object_cleanup_on_exit_test.py
@@ -82,17 +82,13 @@ async def test_cleanup_on_pod_exit(
             }
         ],
     )
+    # Clean up the Ingress
+    await delete_ingress_for_user(mock_kubernetes, name, namespace)
     await asyncio.sleep(0.1)
     # Check that the fileserver user map is clear
     r = await client.get("/nublado/fileserver/v1/users")
     assert r.json() == []
     # Check that the fileserver objects have been deleted
     objs = mock_kubernetes.get_namespace_objects_for_test(namespace=namespace)
-    # Note that namespace objects will still have the Ingress (because
-    # the mock doesn't remove the ingress on GafaelfawrIngress
-    # deletion like the real thing does), and will still have the
-    # Namespace.  So let's check that.
-    assert len(objs) == 2
-    assert {x.kind for x in objs} == {"Ingress", "Namespace"}
-    # Clean up the Ingress
-    await delete_ingress_for_user(mock_kubernetes, name, namespace)
+    assert len(objs) == 1
+    assert objs[0].kind == "Namespace"

--- a/tests/services/state_test.py
+++ b/tests/services/state_test.py
@@ -84,7 +84,7 @@ async def create_lab(
     objects = lab_builder.build_lab(
         user=user, lab=lab, image=image, secrets={}
     )
-    await lab_storage.create_lab(objects)
+    await lab_storage.create(objects)
 
     return UserLabState(
         env=lab.env,


### PR DESCRIPTION
Follow the new builder pattern for fileserver object creation and move the Kubernetes object construction into FileserverBuilder. Move construction of Kubernetes classes for volumes and volume mounts into another small class that can be used by both the LabBuilder and the FileserverBuilder. Move most of the storage layer for the fileserver into a new storage class.

The storage object migration is not yet complete because of state management and the calls to reconstruct state from Kubernetes objects. That redesign will be handled in a subsequent redesign of the separation between the manager and state classes to prepare for Redis separation, after which the old Kubernetes storage layer can be retired completely.

This surfaced a problem with the new watcher class. It was rounding down timeouts instead of rounding them up, which caused functions to be called with a zero timeout. Round up explicitly and also error out if the timeout is set but is 0 or less.