### PR TITLE
DM-41051: Fix arguments to MissingSecretError

### DIFF
--- a/src/jupyterlabcontroller/exceptions.py
+++ b/src/jupyterlabcontroller/exceptions.py
@@ -533,7 +533,7 @@ class MissingSecretError(MissingObjectError):
     """
 
     def __init__(
-        self, namespace: str, name: str, key: str | None = None
+        self, name: str, namespace: str, key: str | None = None
     ) -> None:
         if key:
             message = f"No key {key} in secret {namespace}/{name}"


### PR DESCRIPTION
Switch the argument order to take name first followed by namespace. This is less intuitive but every Kubernetes API uses this ordering, so trying to use a more "natural" order just creates bugs.