### PR TITLE
DM-41051: Use controller namespace as secret source

### DIFF
--- a/src/jupyterlabcontroller/factory.py
+++ b/src/jupyterlabcontroller/factory.py
@@ -341,13 +341,14 @@ class Factory:
         LabManager
             Newly-created lab manager.
         """
+        metadata_storage = MetadataStorage(self._context.config.metadata_path)
         return LabManager(
             instance_url=self._context.config.base_url,
-            manager_namespace=self._context.config.lab.namespace_prefix,
             lab_state=self._context.lab_state,
             lab_builder=self.create_lab_builder(),
             image_service=self._context.image_service,
             size_manager=self.create_size_manager(),
+            metadata_storage=metadata_storage,
             lab_storage=self.create_lab_storage(),
             lab_config=self._context.config.lab,
             slack_client=self.create_slack_client(),

--- a/tests/configs/extra-annotations/input/metadata
+++ b/tests/configs/extra-annotations/input/metadata
@@ -1,0 +1,1 @@
+../../standard/input/metadata

--- a/tests/configs/volume-cases/input/metadata
+++ b/tests/configs/volume-cases/input/metadata
@@ -1,0 +1,1 @@
+../../standard/input/metadata

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,9 +66,9 @@ async def app(
     """
     mock_kubernetes.set_nodes_for_test(obj_factory.nodecontents)
     for secret in obj_factory.secrets:
-        await mock_kubernetes.create_namespaced_secret(
-            config.lab.namespace_prefix, secret
-        )
+        namespace_path = Path(config.metadata_path) / "namespace"
+        namespace = namespace_path.read_text().strip()
+        await mock_kubernetes.create_namespaced_secret(namespace, secret)
     app = create_app()
     async with LifespanManager(app):
         yield app

--- a/tests/handlers/labs_test.py
+++ b/tests/handlers/labs_test.py
@@ -568,7 +568,7 @@ async def test_spawn_errors(
             "read_namespaced_secret",
             "reading object",
             "Secret",
-            "userlabs/extra-secret",
+            "nublado/extra-secret",
         ),
         (
             "create_namespaced_secret",

--- a/tests/services/state_test.py
+++ b/tests/services/state_test.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import timedelta
+from pathlib import Path
 
 import pytest
 from safir.testing.kubernetes import MockKubernetesApi
@@ -183,9 +184,9 @@ async def test_spawn_timeout(
     mock_kubernetes: MockKubernetesApi,
 ) -> None:
     for secret in obj_factory.secrets:
-        await mock_kubernetes.create_namespaced_secret(
-            config.lab.namespace_prefix, secret
-        )
+        namespace_path = Path(config.metadata_path) / "namespace"
+        namespace = namespace_path.read_text().strip()
+        await mock_kubernetes.create_namespaced_secret(namespace, secret)
     mock_kubernetes.initial_pod_phase = PodPhase.PENDING.value
     config.lab.spawn_timeout = timedelta(seconds=1)
     token, user = obj_factory.get_user()


### PR DESCRIPTION
When creating the lab secret, the lab service was still using the namespace prefix for user namespaces as a namespace from which to read secrets, instead of using the namespace of the controller itself. Convert the lab manager to the new MetadataStorage layer so that it is consistent with the rest of the controller, and fix the test suite accordingly.