### PR TITLE
DM-41051: Redo how disabled fileserver is handled

### DIFF
--- a/src/jupyterlabcontroller/exceptions.py
+++ b/src/jupyterlabcontroller/exceptions.py
@@ -21,7 +21,6 @@ from safir.slack.webhook import SlackIgnoredException
 
 __all__ = [
     "ClientRequestError",
-    "DisabledError",
     "DockerRegistryError",
     "DuplicateObjectError",
     "GafaelfawrParseError",
@@ -31,6 +30,7 @@ __all__ = [
     "KubernetesError",
     "LabExistsError",
     "MissingObjectError",
+    "NotConfiguredError",
     "SlackWebException",
     "UnknownDockerImageError",
     "UnknownUserError",
@@ -593,5 +593,8 @@ class FileserverCreationError(ClientRequestError):
     status_code = status.HTTP_400_BAD_REQUEST
 
 
-class DisabledError(SlackException):
+class NotConfiguredError(ClientRequestError):
     """An attempt was made to use a disabled service."""
+
+    error = "not_supported"
+    status_code = status.HTTP_404_NOT_FOUND

--- a/src/jupyterlabcontroller/main.py
+++ b/src/jupyterlabcontroller/main.py
@@ -48,7 +48,6 @@ def create_app() -> FastAPI:
         redoc_url=f"{config.safir.path_prefix}/redoc",
     )
 
-    logger = structlog.get_logger(__name__)
     # Attach the routers.
     app.include_router(index.internal_router)
     app.include_router(index.external_router, prefix=config.safir.path_prefix)
@@ -56,17 +55,16 @@ def create_app() -> FastAPI:
     app.include_router(labs.router, prefix=config.safir.path_prefix)
     app.include_router(prepuller.router, prefix=config.safir.path_prefix)
     app.include_router(user_status.router, prefix=config.safir.path_prefix)
-    if config.fileserver.enabled:
-        logger.info("Enabling fileserver routes")
-        app.include_router(
-            fileserver.user_router, prefix=config.fileserver.path_prefix
-        )
-        app.include_router(fileserver.router, prefix=config.safir.path_prefix)
+    app.include_router(
+        fileserver.user_router, prefix=config.fileserver.path_prefix
+    )
+    app.include_router(fileserver.router, prefix=config.safir.path_prefix)
 
     # Register middleware.
     app.add_middleware(XForwardedMiddleware)
 
     # Configure Slack alerts.
+    logger = structlog.get_logger(__name__)
     if config.slack_webhook:
         webhook = config.slack_webhook
         SlackRouteErrorHandler.initialize(webhook, config.safir.name, logger)


### PR DESCRIPTION
To make testing easier and allow enabling of the fileserver after the FastAPI application has been started, unconditionally register the fileserver routes but raise exceptions in the fileserver state manager if it's not enabled. Change DisabledError to NotConfiguredError to match the exception for the same purpose in Gafaelfawr and configure it to translate into 404 errors for users.