### PR TITLE
DM-41051: Streamline test user handling

### DIFF
--- a/src/jupyterlabcontroller/models/domain/gafaelfawr.py
+++ b/src/jupyterlabcontroller/models/domain/gafaelfawr.py
@@ -127,3 +127,14 @@ class GafaelfawrUser(GafaelfawrUserInfo):
     """
 
     token: str = Field(..., title="Notebook token")
+
+    def to_headers(self) -> dict[str, str]:
+        """Return the representation of this user as HTTP request headers.
+
+        Used primarily by the test suite for constructing authenticated
+        requests from a user.
+        """
+        return {
+            "X-Auth-Request-Token": self.token,
+            "X-Auth-Request-User": self.username,
+        }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ from safir.testing.slack import MockSlackWebhook, mock_slack_webhook
 from jupyterlabcontroller.config import Config
 from jupyterlabcontroller.factory import Factory
 from jupyterlabcontroller.main import create_app
-from jupyterlabcontroller.models.domain.gafaelfawr import GafaelfawrUserInfo
+from jupyterlabcontroller.models.domain.gafaelfawr import GafaelfawrUser
 from jupyterlabcontroller.models.v1.prepuller_config import DockerSourceConfig
 
 from .support.config import configure
@@ -127,12 +127,6 @@ def mock_slack(
 
 
 @pytest.fixture
-def token(mock_gafaelfawr: MockGafaelfawr) -> str:
-    """Authentication token for the user returned by the `user` fixtures."""
-    return mock_gafaelfawr.get_test_token()
-
-
-@pytest.fixture
-def user(mock_gafaelfawr: MockGafaelfawr) -> GafaelfawrUserInfo:
+def user(mock_gafaelfawr: MockGafaelfawr) -> GafaelfawrUser:
     """User to use for testing."""
     return mock_gafaelfawr.get_test_user()

--- a/tests/fileserver/handlers/fileserver_test.py
+++ b/tests/fileserver/handlers/fileserver_test.py
@@ -6,7 +6,7 @@ import pytest
 from httpx import AsyncClient
 from safir.testing.kubernetes import MockKubernetesApi
 
-from jupyterlabcontroller.models.domain.gafaelfawr import GafaelfawrUserInfo
+from jupyterlabcontroller.models.domain.gafaelfawr import GafaelfawrUser
 
 from ...support.config import configure
 from ...support.data import read_output_data
@@ -20,8 +20,7 @@ from ...support.fileserver import (
 @pytest.mark.asyncio
 async def test_fileserver(
     client: AsyncClient,
-    token: str,
-    user: GafaelfawrUserInfo,
+    user: GafaelfawrUser,
     mock_docker: MockDockerRegistry,
     mock_kubernetes: MockKubernetesApi,
 ) -> None:
@@ -41,7 +40,7 @@ async def test_fileserver(
         "/files",
         headers={
             "X-Auth-Request-User": user.username,
-            "X-Auth-Request-Token": token,
+            "X-Auth-Request-Token": user.token,
         },
     )
     assert r.status_code == 200
@@ -58,7 +57,7 @@ async def test_fileserver(
         "/files",
         headers={
             "X-Auth-Request-User": user.username,
-            "X-Auth-Request-Token": token,
+            "X-Auth-Request-Token": user.token,
         },
     )
     assert r.status_code == 200

--- a/tests/fileserver/handlers/fileserver_test.py
+++ b/tests/fileserver/handlers/fileserver_test.py
@@ -36,13 +36,7 @@ async def test_fileserver(
     await create_working_ingress_for_user(mock_kubernetes, name, namespace)
 
     # Start a user fileserver.
-    r = await client.get(
-        "/files",
-        headers={
-            "X-Auth-Request-User": user.username,
-            "X-Auth-Request-Token": user.token,
-        },
-    )
+    r = await client.get("/files", headers=user.to_headers())
     assert r.status_code == 200
     expected = read_output_data("fileserver", "fileserver.txt")
     assert r.text == expected
@@ -53,13 +47,7 @@ async def test_fileserver(
     # Request it again; should detect that there is a user fileserver and
     # return immediately without actually doing anything.
     #
-    r = await client.get(
-        "/files",
-        headers={
-            "X-Auth-Request-User": user.username,
-            "X-Auth-Request-Token": user.token,
-        },
-    )
+    r = await client.get("/files", headers=user.to_headers())
     assert r.status_code == 200
     assert r.text == expected
     # Make sure fileserver still exists

--- a/tests/fileserver/handlers/object_cleanup_on_exit_test.py
+++ b/tests/fileserver/handlers/object_cleanup_on_exit_test.py
@@ -49,13 +49,7 @@ async def test_cleanup_on_pod_exit(
     # life, the GafaelfawrIngress creation would trigger this.
     await create_working_ingress_for_user(mock_kubernetes, name, namespace)
     # Start a user fileserver.
-    r = await client.get(
-        "/files",
-        headers={
-            "X-Auth-Request-User": user.username,
-            "X-Auth-Request-Token": user.token,
-        },
-    )
+    r = await client.get("/files", headers=user.to_headers())
     assert r.status_code == 200
     # Check that it has showed up, via an admin route.
     r = await client.get("/nublado/fileserver/v1/users")

--- a/tests/fileserver/handlers/object_cleanup_on_exit_test.py
+++ b/tests/fileserver/handlers/object_cleanup_on_exit_test.py
@@ -10,7 +10,7 @@ from httpx import AsyncClient
 from kubernetes_asyncio.client import V1Pod
 from safir.testing.kubernetes import MockKubernetesApi
 
-from jupyterlabcontroller.models.domain.gafaelfawr import GafaelfawrUserInfo
+from jupyterlabcontroller.models.domain.gafaelfawr import GafaelfawrUser
 from jupyterlabcontroller.models.domain.kubernetes import PodPhase
 
 from ...support.config import configure
@@ -34,8 +34,7 @@ def _find_user_pod(user: str, objects: list[Any]) -> V1Pod:
 @pytest.mark.asyncio
 async def test_cleanup_on_pod_exit(
     client: AsyncClient,
-    token: str,
-    user: GafaelfawrUserInfo,
+    user: GafaelfawrUser,
     mock_docker: MockDockerRegistry,
     mock_kubernetes: MockKubernetesApi,
 ) -> None:
@@ -54,7 +53,7 @@ async def test_cleanup_on_pod_exit(
         "/files",
         headers={
             "X-Auth-Request-User": user.username,
-            "X-Auth-Request-Token": token,
+            "X-Auth-Request-Token": user.token,
         },
     )
     assert r.status_code == 200

--- a/tests/fileserver/handlers/timeout_test.py
+++ b/tests/fileserver/handlers/timeout_test.py
@@ -8,7 +8,7 @@ import pytest
 from httpx import AsyncClient
 from safir.testing.kubernetes import MockKubernetesApi
 
-from jupyterlabcontroller.models.domain.gafaelfawr import GafaelfawrUserInfo
+from jupyterlabcontroller.models.domain.gafaelfawr import GafaelfawrUser
 
 from ...support.config import configure
 from ...support.docker import MockDockerRegistry
@@ -22,8 +22,7 @@ from ...support.fileserver import (
 @pytest.mark.asyncio
 async def test_timeout_no_pod_start(
     client: AsyncClient,
-    token: str,
-    user: GafaelfawrUserInfo,
+    user: GafaelfawrUser,
     mock_docker: MockDockerRegistry,
     mock_kubernetes: MockKubernetesApi,
 ) -> None:
@@ -50,7 +49,7 @@ async def test_timeout_no_pod_start(
             "/files",
             headers={
                 "X-Auth-Request-User": name,
-                "X-Auth-Request-Token": token,
+                "X-Auth-Request-Token": user.token,
             },
         )
     )
@@ -74,8 +73,7 @@ async def test_timeout_no_pod_start(
 @pytest.mark.asyncio
 async def test_timeout_no_ingress(
     client: AsyncClient,
-    token: str,
-    user: GafaelfawrUserInfo,
+    user: GafaelfawrUser,
     mock_docker: MockDockerRegistry,
     mock_kubernetes: MockKubernetesApi,
 ) -> None:
@@ -94,7 +92,7 @@ async def test_timeout_no_ingress(
             "/files",
             headers={
                 "X-Auth-Request-User": user.username,
-                "X-Auth-Request-Token": token,
+                "X-Auth-Request-Token": user.token,
             },
         )
     # Check that the fileserver user map is still clear
@@ -107,8 +105,7 @@ async def test_timeout_no_ingress(
 @pytest.mark.asyncio
 async def test_timeout_no_ingress_ip(
     client: AsyncClient,
-    token: str,
-    user: GafaelfawrUserInfo,
+    user: GafaelfawrUser,
     mock_docker: MockDockerRegistry,
     mock_kubernetes: MockKubernetesApi,
 ) -> None:
@@ -128,7 +125,7 @@ async def test_timeout_no_ingress_ip(
             "/files",
             headers={
                 "X-Auth-Request-User": user.username,
-                "X-Auth-Request-Token": token,
+                "X-Auth-Request-Token": user.token,
             },
         )
 

--- a/tests/fileserver/handlers/wait_for_ingress.py
+++ b/tests/fileserver/handlers/wait_for_ingress.py
@@ -32,23 +32,16 @@ async def test_wait_for_ingress(
     # No fileservers yet.
     assert r.json() == []
 
-    #
-    async def create_fileserver() -> None:
-        # Start a user fileserver.
-        r = await client.get(
-            "/files",
-            headers={
-                "X-Auth-Request-User": user.username,
-                "X-Auth-Request-Token": user.token,
-            },
-        )
+    async def start_fileserver() -> None:
+        r = await client.get("/files", headers=user.to_headers())
         assert r.status_code == 200
+
         # Check that it has showed up, via an admin route.
         r = await client.get("/nublado/fileserver/v1/users")
         assert r.json() == [user.username]
 
     # Start the fileserver
-    task = asyncio.create_task(create_fileserver())
+    task = asyncio.create_task(start_fileserver())
     # Check that task is running
     assert task.done() is False
     # Check there are no fileservers yet.

--- a/tests/fileserver/handlers/wait_for_ingress.py
+++ b/tests/fileserver/handlers/wait_for_ingress.py
@@ -8,7 +8,7 @@ import pytest
 from httpx import AsyncClient
 from safir.testing.kubernetes import MockKubernetesApi
 
-from jupyterlabcontroller.models.domain.gafaelfawr import GafaelfawrUserInfo
+from jupyterlabcontroller.models.domain.gafaelfawr import GafaelfawrUser
 
 from ...support.config import configure
 from ...support.docker import MockDockerRegistry
@@ -21,8 +21,7 @@ from ...support.fileserver import (
 @pytest.mark.asyncio
 async def test_wait_for_ingress(
     client: AsyncClient,
-    token: str,
-    user: GafaelfawrUserInfo,
+    user: GafaelfawrUser,
     mock_docker: MockDockerRegistry,
     mock_kubernetes: MockKubernetesApi,
 ) -> None:
@@ -40,7 +39,7 @@ async def test_wait_for_ingress(
             "/files",
             headers={
                 "X-Auth-Request-User": user.username,
-                "X-Auth-Request-Token": token,
+                "X-Auth-Request-Token": user.token,
             },
         )
         assert r.status_code == 200

--- a/tests/handlers/extra_annotations_test.py
+++ b/tests/handlers/extra_annotations_test.py
@@ -25,10 +25,7 @@ async def test_extra_annotations(
     r = await client.post(
         f"/nublado/spawner/v1/labs/{user.username}/create",
         json={"options": lab.options.model_dump(), "env": lab.env},
-        headers={
-            "X-Auth-Request-Token": user.token,
-            "X-Auth-Request-User": user.username,
-        },
+        headers=user.to_headers(),
     )
     assert r.status_code == 201
 

--- a/tests/handlers/extra_annotations_test.py
+++ b/tests/handlers/extra_annotations_test.py
@@ -6,7 +6,7 @@ import pytest
 from httpx import AsyncClient
 from safir.testing.kubernetes import MockKubernetesApi
 
-from jupyterlabcontroller.models.domain.gafaelfawr import GafaelfawrUserInfo
+from jupyterlabcontroller.models.domain.gafaelfawr import GafaelfawrUser
 
 from ..support.config import configure
 from ..support.data import read_input_lab_specification_json
@@ -15,8 +15,7 @@ from ..support.data import read_input_lab_specification_json
 @pytest.mark.asyncio
 async def test_extra_annotations(
     client: AsyncClient,
-    token: str,
-    user: GafaelfawrUserInfo,
+    user: GafaelfawrUser,
     mock_kubernetes: MockKubernetesApi,
 ) -> None:
     """Check that the pod picks up extra annotations set in the config."""
@@ -27,7 +26,7 @@ async def test_extra_annotations(
         f"/nublado/spawner/v1/labs/{user.username}/create",
         json={"options": lab.options.model_dump(), "env": lab.env},
         headers={
-            "X-Auth-Request-Token": token,
+            "X-Auth-Request-Token": user.token,
             "X-Auth-Request-User": user.username,
         },
     )

--- a/tests/handlers/form_test.py
+++ b/tests/handlers/form_test.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 import pytest
 from httpx import AsyncClient
 
-from jupyterlabcontroller.models.domain.gafaelfawr import GafaelfawrUserInfo
+from jupyterlabcontroller.models.domain.gafaelfawr import GafaelfawrUser
 
 from ..support.data import read_output_data
 
 
 @pytest.mark.asyncio
-async def test_lab_form(client: AsyncClient, user: GafaelfawrUserInfo) -> None:
+async def test_lab_form(client: AsyncClient, user: GafaelfawrUser) -> None:
     r = await client.get(
         f"/nublado/spawner/v1/lab-form/{user.username}",
         headers={"X-Auth-Request-User": user.username},

--- a/tests/handlers/form_test.py
+++ b/tests/handlers/form_test.py
@@ -14,7 +14,7 @@ from ..support.data import read_output_data
 async def test_lab_form(client: AsyncClient, user: GafaelfawrUser) -> None:
     r = await client.get(
         f"/nublado/spawner/v1/lab-form/{user.username}",
-        headers={"X-Auth-Request-User": user.username},
+        headers=user.to_headers(),
     )
     assert r.status_code == 200
     assert r.headers["Content-Type"] == "text/html; charset=utf-8"

--- a/tests/handlers/labs_test.py
+++ b/tests/handlers/labs_test.py
@@ -22,7 +22,7 @@ from safir.testing.slack import MockSlackWebhook
 from jupyterlabcontroller.config import Config
 from jupyterlabcontroller.constants import DROPDOWN_SENTINEL_VALUE
 from jupyterlabcontroller.factory import Factory
-from jupyterlabcontroller.models.domain.gafaelfawr import GafaelfawrUserInfo
+from jupyterlabcontroller.models.domain.gafaelfawr import GafaelfawrUser
 from jupyterlabcontroller.models.domain.kubernetes import PodPhase
 
 from ..support.config import configure
@@ -64,8 +64,7 @@ async def get_lab_events(
 async def test_lab_start_stop(
     client: AsyncClient,
     factory: Factory,
-    token: str,
-    user: GafaelfawrUserInfo,
+    user: GafaelfawrUser,
     mock_kubernetes: MockKubernetesApi,
 ) -> None:
     assert user.quota
@@ -114,7 +113,7 @@ async def test_lab_start_stop(
             "env": lab.env,
         },
         headers={
-            "X-Auth-Request-Token": token,
+            "X-Auth-Request-Token": user.token,
             "X-Auth-Request-User": user.username,
         },
     )
@@ -172,7 +171,7 @@ async def test_lab_start_stop(
         f"/nublado/spawner/v1/labs/{user.username}/create",
         json={"options": lab.options.model_dump(), "env": lab.env},
         headers={
-            "X-Auth-Request-Token": token,
+            "X-Auth-Request-Token": user.token,
             "X-Auth-Request-User": user.username,
         },
     )
@@ -220,8 +219,7 @@ async def test_lab_start_stop(
 async def test_spawn_after_failure(
     client: AsyncClient,
     factory: Factory,
-    token: str,
-    user: GafaelfawrUserInfo,
+    user: GafaelfawrUser,
     mock_kubernetes: MockKubernetesApi,
 ) -> None:
     lab = read_input_lab_specification_json("base", "lab-specification.json")
@@ -231,7 +229,7 @@ async def test_spawn_after_failure(
         f"/nublado/spawner/v1/labs/{user.username}/create",
         json={"options": lab.options.model_dump(), "env": lab.env},
         headers={
-            "X-Auth-Request-Token": token,
+            "X-Auth-Request-Token": user.token,
             "X-Auth-Request-User": user.username,
         },
     )
@@ -264,7 +262,7 @@ async def test_spawn_after_failure(
         f"/nublado/spawner/v1/labs/{user.username}/create",
         json={"options": lab.options.model_dump(), "env": lab.env},
         headers={
-            "X-Auth-Request-Token": token,
+            "X-Auth-Request-Token": user.token,
             "X-Auth-Request-User": user.username,
         },
     )
@@ -284,8 +282,7 @@ async def test_spawn_after_failure(
 async def test_delayed_spawn(
     client: AsyncClient,
     factory: Factory,
-    token: str,
-    user: GafaelfawrUserInfo,
+    user: GafaelfawrUser,
     mock_kubernetes: MockKubernetesApi,
 ) -> None:
     lab = read_input_lab_specification_json("base", "lab-specification.json")
@@ -295,7 +292,7 @@ async def test_delayed_spawn(
         f"/nublado/spawner/v1/labs/{user.username}/create",
         json={"options": lab.options.model_dump(), "env": lab.env},
         headers={
-            "X-Auth-Request-Token": token,
+            "X-Auth-Request-Token": user.token,
             "X-Auth-Request-User": user.username,
         },
     )
@@ -395,8 +392,7 @@ async def test_delayed_spawn(
 async def test_lab_objects(
     client: AsyncClient,
     config: Config,
-    token: str,
-    user: GafaelfawrUserInfo,
+    user: GafaelfawrUser,
     mock_kubernetes: MockKubernetesApi,
 ) -> None:
     lab = read_input_lab_specification_json("base", "lab-specification.json")
@@ -405,7 +401,7 @@ async def test_lab_objects(
         f"/nublado/spawner/v1/labs/{user.username}/create",
         json={"options": lab.options.model_dump(), "env": lab.env},
         headers={
-            "X-Auth-Request-Token": token,
+            "X-Auth-Request-Token": user.token,
             "X-Auth-Request-User": user.username,
         },
     )
@@ -423,9 +419,7 @@ async def test_lab_objects(
 
 
 @pytest.mark.asyncio
-async def test_errors(
-    client: AsyncClient, token: str, user: GafaelfawrUserInfo
-) -> None:
+async def test_errors(client: AsyncClient, user: GafaelfawrUser) -> None:
     lab = read_input_lab_specification_json("base", "lab-specification.json")
 
     # Wrong user.
@@ -433,7 +427,7 @@ async def test_errors(
         "/nublado/spawner/v1/labs/otheruser/create",
         json={"options": lab.options.model_dump(), "env": lab.env},
         headers={
-            "X-Auth-Request-Token": token,
+            "X-Auth-Request-Token": user.token,
             "X-Auth-Request-User": user.username,
         },
     )
@@ -471,7 +465,7 @@ async def test_errors(
         f"/nublado/spawner/v1/labs/{user.username}/create",
         json={"options": options, "env": lab.env},
         headers={
-            "X-Auth-Request-Token": token,
+            "X-Auth-Request-Token": user.token,
             "X-Auth-Request-User": user.username,
         },
     )
@@ -495,7 +489,7 @@ async def test_errors(
         f"/nublado/spawner/v1/labs/{user.username}/create",
         json={"options": options, "env": lab.env},
         headers={
-            "X-Auth-Request-Token": token,
+            "X-Auth-Request-Token": user.token,
             "X-Auth-Request-User": user.username,
         },
     )
@@ -519,7 +513,7 @@ async def test_errors(
             "env": lab.env,
         },
         headers={
-            "X-Auth-Request-Token": token,
+            "X-Auth-Request-Token": user.token,
             "X-Auth-Request-User": user.username,
         },
     )
@@ -538,8 +532,7 @@ async def test_errors(
 @pytest.mark.asyncio
 async def test_spawn_errors(
     client: AsyncClient,
-    token: str,
-    user: GafaelfawrUserInfo,
+    user: GafaelfawrUser,
     mock_kubernetes: MockKubernetesApi,
     mock_slack: MockSlackWebhook,
 ) -> None:
@@ -611,7 +604,7 @@ async def test_spawn_errors(
             f"/nublado/spawner/v1/labs/{user.username}/create",
             json={"options": lab.options.model_dump(), "env": lab.env},
             headers={
-                "X-Auth-Request-Token": token,
+                "X-Auth-Request-Token": user.token,
                 "X-Auth-Request-User": user.username,
             },
         )
@@ -690,8 +683,7 @@ async def test_spawn_errors(
 @pytest.mark.asyncio
 async def test_homedir_schema(
     client: AsyncClient,
-    token: str,
-    user: GafaelfawrUserInfo,
+    user: GafaelfawrUser,
     mock_kubernetes: MockKubernetesApi,
 ) -> None:
     """Check that the home directory is constructed correctly.
@@ -707,7 +699,7 @@ async def test_homedir_schema(
         f"/nublado/spawner/v1/labs/{user.username}/create",
         json={"options": lab.options.model_dump(), "env": lab.env},
         headers={
-            "X-Auth-Request-Token": token,
+            "X-Auth-Request-Token": user.token,
             "X-Auth-Request-User": user.username,
         },
     )

--- a/tests/handlers/labs_test.py
+++ b/tests/handlers/labs_test.py
@@ -90,13 +90,12 @@ async def test_lab_start_stop(
     assert r.json() == unknown_user_error
     r = await client.get(
         f"/nublado/spawner/v1/labs/{user.username}/events",
-        headers={"X-Auth-Request-User": user.username},
+        headers=user.to_headers(),
     )
     assert r.status_code == 404
     assert r.json() == unknown_user_error
     r = await client.delete(
-        f"/nublado/spawner/v1/labs/{user.username}",
-        headers={"X-Auth-Request-User": user.username},
+        f"/nublado/spawner/v1/labs/{user.username}", headers=user.to_headers()
     )
     assert r.status_code == 404
     assert r.json() == unknown_user_error
@@ -112,10 +111,7 @@ async def test_lab_start_stop(
             },
             "env": lab.env,
         },
-        headers={
-            "X-Auth-Request-Token": user.token,
-            "X-Auth-Request-User": user.username,
-        },
+        headers=user.to_headers(),
     )
     assert r.status_code == 201
     assert r.headers["Location"] == (
@@ -128,7 +124,7 @@ async def test_lab_start_stop(
     # of the events isn't tested here in detail; we'll do that separately.
     r = await client.get(
         f"/nublado/spawner/v1/labs/{user.username}/events",
-        headers={"X-Auth-Request-User": user.username},
+        headers=user.to_headers(),
     )
     assert r.status_code == 200
     assert "Lab Kubernetes pod started" in r.text
@@ -170,10 +166,7 @@ async def test_lab_start_stop(
     r = await client.post(
         f"/nublado/spawner/v1/labs/{user.username}/create",
         json={"options": lab.options.model_dump(), "env": lab.env},
-        headers={
-            "X-Auth-Request-Token": user.token,
-            "X-Auth-Request-User": user.username,
-        },
+        headers=user.to_headers(),
     )
     assert r.status_code == 409
     assert r.json() == {
@@ -228,10 +221,7 @@ async def test_spawn_after_failure(
     r = await client.post(
         f"/nublado/spawner/v1/labs/{user.username}/create",
         json={"options": lab.options.model_dump(), "env": lab.env},
-        headers={
-            "X-Auth-Request-Token": user.token,
-            "X-Auth-Request-User": user.username,
-        },
+        headers=user.to_headers(),
     )
     assert r.status_code == 201
     assert r.headers["Location"] == (
@@ -261,10 +251,7 @@ async def test_spawn_after_failure(
     r = await client.post(
         f"/nublado/spawner/v1/labs/{user.username}/create",
         json={"options": lab.options.model_dump(), "env": lab.env},
-        headers={
-            "X-Auth-Request-Token": user.token,
-            "X-Auth-Request-User": user.username,
-        },
+        headers=user.to_headers(),
     )
     assert r.status_code == 201
     assert r.headers["Location"] == (
@@ -291,10 +278,7 @@ async def test_delayed_spawn(
     r = await client.post(
         f"/nublado/spawner/v1/labs/{user.username}/create",
         json={"options": lab.options.model_dump(), "env": lab.env},
-        headers={
-            "X-Auth-Request-Token": user.token,
-            "X-Auth-Request-User": user.username,
-        },
+        headers=user.to_headers(),
     )
     assert r.status_code == 201
     r = await client.get(f"/nublado/spawner/v1/labs/{user.username}")
@@ -400,10 +384,7 @@ async def test_lab_objects(
     r = await client.post(
         f"/nublado/spawner/v1/labs/{user.username}/create",
         json={"options": lab.options.model_dump(), "env": lab.env},
-        headers={
-            "X-Auth-Request-Token": user.token,
-            "X-Auth-Request-User": user.username,
-        },
+        headers=user.to_headers(),
     )
     assert r.status_code == 201
 
@@ -426,18 +407,14 @@ async def test_errors(client: AsyncClient, user: GafaelfawrUser) -> None:
     r = await client.post(
         "/nublado/spawner/v1/labs/otheruser/create",
         json={"options": lab.options.model_dump(), "env": lab.env},
-        headers={
-            "X-Auth-Request-Token": user.token,
-            "X-Auth-Request-User": user.username,
-        },
+        headers=user.to_headers(),
     )
     assert r.status_code == 403
     assert r.json() == {
         "detail": [{"msg": "Permission denied", "type": "permission_denied"}]
     }
     r = await client.get(
-        "/nublado/spawner/v1/labs/otheruser/events",
-        headers={"X-Auth-Request-User": user.username},
+        "/nublado/spawner/v1/labs/otheruser/events", headers=user.to_headers()
     )
     assert r.status_code == 403
     assert r.json() == {
@@ -464,10 +441,7 @@ async def test_errors(client: AsyncClient, user: GafaelfawrUser) -> None:
     r = await client.post(
         f"/nublado/spawner/v1/labs/{user.username}/create",
         json={"options": options, "env": lab.env},
-        headers={
-            "X-Auth-Request-Token": user.token,
-            "X-Auth-Request-User": user.username,
-        },
+        headers=user.to_headers(),
     )
     assert r.status_code == 422
     msg = 'Docker reference "lighthouse.ceres/library/sketchbook" has no tag'
@@ -488,10 +462,7 @@ async def test_errors(client: AsyncClient, user: GafaelfawrUser) -> None:
     r = await client.post(
         f"/nublado/spawner/v1/labs/{user.username}/create",
         json={"options": options, "env": lab.env},
-        headers={
-            "X-Auth-Request-Token": user.token,
-            "X-Auth-Request-User": user.username,
-        },
+        headers=user.to_headers(),
     )
     assert r.status_code == 422
     msg = 'Docker reference "lighthouse.ceres/library/sketchbook" has no tag'
@@ -512,10 +483,7 @@ async def test_errors(client: AsyncClient, user: GafaelfawrUser) -> None:
             "options": {"image_tag": "unknown", "size": "small"},
             "env": lab.env,
         },
-        headers={
-            "X-Auth-Request-Token": user.token,
-            "X-Auth-Request-User": user.username,
-        },
+        headers=user.to_headers(),
     )
     assert r.status_code == 400
     assert r.json() == {
@@ -603,10 +571,7 @@ async def test_spawn_errors(
         r = await client.post(
             f"/nublado/spawner/v1/labs/{user.username}/create",
             json={"options": lab.options.model_dump(), "env": lab.env},
-            headers={
-                "X-Auth-Request-Token": user.token,
-                "X-Auth-Request-User": user.username,
-            },
+            headers=user.to_headers(),
         )
         assert r.status_code == 201
         events = await get_lab_events(client, user.username)
@@ -698,10 +663,7 @@ async def test_homedir_schema(
     r = await client.post(
         f"/nublado/spawner/v1/labs/{user.username}/create",
         json={"options": lab.options.model_dump(), "env": lab.env},
-        headers={
-            "X-Auth-Request-Token": user.token,
-            "X-Auth-Request-User": user.username,
-        },
+        headers=user.to_headers(),
     )
     assert r.status_code == 201
 

--- a/tests/handlers/user_status_test.py
+++ b/tests/handlers/user_status_test.py
@@ -28,8 +28,7 @@ async def test_user_status(
 
     # At the start, we shouldn't have any lab.
     r = await client.get(
-        "/nublado/spawner/v1/user-status",
-        headers={"X-Auth-Request-User": user.username},
+        "/nublado/spawner/v1/user-status", headers=user.to_headers()
     )
     assert r.status_code == 404
     assert r.json() == {
@@ -48,10 +47,7 @@ async def test_user_status(
             },
             "env": lab.env,
         },
-        headers={
-            "X-Auth-Request-Token": user.token,
-            "X-Auth-Request-User": user.username,
-        },
+        headers=user.to_headers(),
     )
     assert r.status_code == 201
     assert r.headers["Location"] == (
@@ -60,8 +56,7 @@ async def test_user_status(
 
     # Now the lab should exist and we should be able to get some user status.
     r = await client.get(
-        "/nublado/spawner/v1/user-status",
-        headers={"X-Auth-Request-User": user.username},
+        "/nublado/spawner/v1/user-status", headers=user.to_headers()
     )
     assert r.status_code == 200
     expected_resources = size_manager.resources(lab.options.size)
@@ -92,8 +87,7 @@ async def test_user_status(
     pod = await mock_kubernetes.read_namespaced_pod(name, namespace)
     pod.status.phase = PodPhase.FAILED.value
     r = await client.get(
-        "/nublado/spawner/v1/user-status",
-        headers={"X-Auth-Request-User": user.username},
+        "/nublado/spawner/v1/user-status", headers=user.to_headers()
     )
     assert r.status_code == 200
     expected["status"] = "failed"
@@ -103,8 +97,7 @@ async def test_user_status(
     # the pod status.
     await mock_kubernetes.delete_namespaced_pod(name, namespace)
     r = await client.get(
-        "/nublado/spawner/v1/user-status",
-        headers={"X-Auth-Request-User": user.username},
+        "/nublado/spawner/v1/user-status", headers=user.to_headers()
     )
     assert r.status_code == 200
     expected["pod"] = "missing"

--- a/tests/handlers/user_status_test.py
+++ b/tests/handlers/user_status_test.py
@@ -7,7 +7,7 @@ from httpx import AsyncClient
 from safir.testing.kubernetes import MockKubernetesApi
 
 from jupyterlabcontroller.factory import Factory
-from jupyterlabcontroller.models.domain.gafaelfawr import GafaelfawrUserInfo
+from jupyterlabcontroller.models.domain.gafaelfawr import GafaelfawrUser
 from jupyterlabcontroller.models.domain.kubernetes import PodPhase
 
 from ..support.constants import TEST_BASE_URL
@@ -18,8 +18,7 @@ from ..support.data import read_input_lab_specification_json
 async def test_user_status(
     client: AsyncClient,
     factory: Factory,
-    token: str,
-    user: GafaelfawrUserInfo,
+    user: GafaelfawrUser,
     mock_kubernetes: MockKubernetesApi,
 ) -> None:
     assert user.quota
@@ -50,7 +49,7 @@ async def test_user_status(
             "env": lab.env,
         },
         headers={
-            "X-Auth-Request-Token": token,
+            "X-Auth-Request-Token": user.token,
             "X-Auth-Request-User": user.username,
         },
     )

--- a/tests/handlers/volume_cases_test.py
+++ b/tests/handlers/volume_cases_test.py
@@ -24,10 +24,7 @@ async def test_volume_cases(
     r = await client.post(
         f"/nublado/spawner/v1/labs/{user.username}/create",
         json={"options": lab.options.model_dump(), "env": lab.env},
-        headers={
-            "X-Auth-Request-Token": user.token,
-            "X-Auth-Request-User": user.username,
-        },
+        headers=user.to_headers(),
     )
     assert r.status_code == 201
 

--- a/tests/handlers/volume_cases_test.py
+++ b/tests/handlers/volume_cases_test.py
@@ -6,7 +6,7 @@ import pytest
 from httpx import AsyncClient
 from safir.testing.kubernetes import MockKubernetesApi
 
-from jupyterlabcontroller.models.domain.gafaelfawr import GafaelfawrUserInfo
+from jupyterlabcontroller.models.domain.gafaelfawr import GafaelfawrUser
 
 from ..support.config import configure
 from ..support.data import read_input_lab_specification_json
@@ -15,8 +15,7 @@ from ..support.data import read_input_lab_specification_json
 @pytest.mark.asyncio
 async def test_volume_cases(
     client: AsyncClient,
-    token: str,
-    user: GafaelfawrUserInfo,
+    user: GafaelfawrUser,
     mock_kubernetes: MockKubernetesApi,
 ) -> None:
     config = await configure("volume-cases")
@@ -26,7 +25,7 @@ async def test_volume_cases(
         f"/nublado/spawner/v1/labs/{user.username}/create",
         json={"options": lab.options.model_dump(), "env": lab.env},
         headers={
-            "X-Auth-Request-Token": token,
+            "X-Auth-Request-Token": user.token,
             "X-Auth-Request-User": user.username,
         },
     )

--- a/tests/support/gafaelfawr.py
+++ b/tests/support/gafaelfawr.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import respx
 from httpx import Request, Response
 
-from jupyterlabcontroller.models.domain.gafaelfawr import GafaelfawrUserInfo
+from jupyterlabcontroller.models.domain.gafaelfawr import (
+    GafaelfawrUser,
+    GafaelfawrUserInfo,
+)
 
 __all__ = ["MockGafaelfawr", "register_mock_gafaelfawr"]
 
@@ -46,13 +49,10 @@ class MockGafaelfawr:
         else:
             return Response(403)
 
-    def get_test_token(self) -> str:
+    def get_test_user(self) -> GafaelfawrUser:
         """Get a token for tests."""
-        return next(iter(self._tokens))
-
-    def get_test_user(self) -> GafaelfawrUserInfo:
-        """Get a user for tests."""
-        return next(iter(self._tokens.values()))
+        token, user = next(iter(self._tokens.items()))
+        return GafaelfawrUser(token=token, **user.model_dump())
 
 
 def register_mock_gafaelfawr(


### PR DESCRIPTION
Take advantage of the new `GafaelfawrUser` model to return a single object instead of separate token and user fixtures, and add a method to it to turn a user back into the headers that would be sent by Gafaelfawr as a convenience for tests. Use that everywhere instead of constructing the headers manually except in places where the manual construction adds more test surface.