### PR TITLE
DM-41051: Add support for homedir prefix and suffix

### DIFF
--- a/src/jupyterlabcontroller/config.py
+++ b/src/jupyterlabcontroller/config.py
@@ -309,7 +309,14 @@ class LabConfig(CamelCaseModel):
     homedir_prefix: str = Field(
         "/home",
         title="Prefix for home directory path",
-        description="Portion of home directory path added before the username",
+        description=(
+            "Portion of home directory path added before the username. This"
+            " is the path *inside* the container, not the path of the volume"
+            " mounted in the container, so it need not reflect the structure"
+            " of the home directory volume source. The primary reason to set"
+            " this is to make paths inside the container match a pattern that"
+            " users are familiar with outside of Nublado."
+        ),
     )
     homedir_schema: UserHomeDirectorySchema = Field(
         UserHomeDirectorySchema.USERNAME,
@@ -335,7 +342,10 @@ class LabConfig(CamelCaseModel):
     @field_validator("homedir_prefix")
     @classmethod
     def _validate_homedir_prefix(cls, v: str) -> str:
-        return v.rstrip("/")
+        v = v.rstrip("/")
+        if not v.startswith("/") or len(v) < 2:
+            raise ValueError("Invalid home directory prefix")
+        return v
 
     @field_validator("homedir_suffix")
     @classmethod

--- a/src/jupyterlabcontroller/config.py
+++ b/src/jupyterlabcontroller/config.py
@@ -306,9 +306,19 @@ class LabConfig(CamelCaseModel):
         default_factory=_get_namespace_prefix,
         title="Namespace prefix for lab environments",
     )
+    homedir_prefix: str = Field(
+        "/home",
+        title="Prefix for home directory path",
+        description="Portion of home directory path added before the username",
+    )
     homedir_schema: UserHomeDirectorySchema = Field(
         UserHomeDirectorySchema.USERNAME,
         title="Schema for user homedir construction",
+    )
+    homedir_suffix: str = Field(
+        "",
+        title="Suffix for home directory path",
+        description="Portion of home directory path added after the username",
     )
     extra_annotations: dict[str, str] = Field(
         {},
@@ -321,6 +331,16 @@ class LabConfig(CamelCaseModel):
             "An Argo CD application under which lab objects should be shown"
         ),
     )
+
+    @field_validator("homedir_prefix")
+    @classmethod
+    def _validate_homedir_prefix(cls, v: str) -> str:
+        return v.rstrip("/")
+
+    @field_validator("homedir_suffix")
+    @classmethod
+    def _validate_homedir_suffix(cls, v: str) -> str:
+        return v.strip("/")
 
     @field_validator("secrets")
     @classmethod

--- a/src/jupyterlabcontroller/services/builder/lab.py
+++ b/src/jupyterlabcontroller/services/builder/lab.py
@@ -209,11 +209,15 @@ class LabBuilder:
 
     def _build_home_directory(self, username: str) -> str:
         """Construct the home directory path for a user."""
+        prefix = self._config.homedir_prefix
         match self._config.homedir_schema:
             case UserHomeDirectorySchema.USERNAME:
-                return f"/home/{username}"
+                home = prefix + f"/{username}"
             case UserHomeDirectorySchema.INITIAL_THEN_USERNAME:
-                return f"/home/{username[0]}/{username}"
+                home = prefix + f"/{username[0]}/{username}"
+        if self._config.homedir_suffix:
+            home += "/" + self._config.homedir_suffix
+        return home
 
     def _build_metadata(self, name: str, username: str) -> V1ObjectMeta:
         """Construct the metadata for an object.

--- a/tests/data/homedir-schema/input/config.yaml
+++ b/tests/data/homedir-schema/input/config.yaml
@@ -2,7 +2,12 @@ safir:
   profile: development
   logLevel: DEBUG
 lab:
+  # The prefix and suffix have extra slashes to test the validator. Normal
+  # configurations should not have trailing slashes in the prefix and should
+  # not have leading or trailing slashes in the suffix.
+  homedirPrefix: "/u/home/"
   homedirSchema: initialThenUsername
+  homedirSuffix: "/jhome/"
   files:
     /etc/passwd:
       modify: true
@@ -17,7 +22,7 @@ lab:
       cpu: 1.0
       memory: 3Gi
   volumes:
-    - containerPath: /home
+    - containerPath: /u/home
       mode: rw
       source:
         type: nfs

--- a/tests/data/homedir-schema/output/passwd
+++ b/tests/data/homedir-schema/output/passwd
@@ -1,2 +1,2 @@
 root:x:0:0:root:/root:/bin/bash
-rachel:x:1101:1101:Rachel (?):/home/r/rachel:/bin/bash
+rachel:x:1101:1101:Rachel (?):/u/home/r/rachel/jhome:/bin/bash

--- a/tests/handlers/labs_test.py
+++ b/tests/handlers/labs_test.py
@@ -678,7 +678,7 @@ async def test_homedir_schema(
         f"{user.username}-nb",
         f"{config.lab.namespace_prefix}-{user.username}",
     )
-    expected_homedir = f"/home/{user.username[0]}/{user.username}"
+    expected_homedir = f"/u/home/{user.username[0]}/{user.username}/jhome"
     for container in pod.spec.containers:
         assert container.working_dir == expected_homedir
 


### PR DESCRIPTION
Allow the prefix for home directories (normally /home) and the suffix (normally empty, but allowing the home directory for labs to be a subdirectory of the user's normal home directory) to be configured.

I picked this approach over adding template support because I don't like having to document a template language in user documentation and try to explain what variables are available and how to write a template. In this case, I think the three options are reasonably easy to understand and avoid the need for a full-blown templating mini-language.