### PR TITLE
DM-41350: Use Safir ClientRequestError and SlackWebException

### DIFF
--- a/src/jupyterlabcontroller/exceptions.py
+++ b/src/jupyterlabcontroller/exceptions.py
@@ -2,25 +2,22 @@
 
 from __future__ import annotations
 
-from datetime import datetime
-from typing import ClassVar, Self
+from typing import Self
 
 from fastapi import status
-from httpx import HTTPError, HTTPStatusError, RequestError
 from kubernetes_asyncio.client import ApiException
 from pydantic import ValidationError
-from safir.models import ErrorLocation
+from safir.fastapi import ClientRequestError
 from safir.slack.blockkit import (
     SlackCodeBlock,
     SlackException,
     SlackMessage,
     SlackTextBlock,
     SlackTextField,
+    SlackWebException,
 )
-from safir.slack.webhook import SlackIgnoredException
 
 __all__ = [
-    "ClientRequestError",
     "DockerRegistryError",
     "DuplicateObjectError",
     "GafaelfawrParseError",
@@ -33,92 +30,9 @@ __all__ = [
     "MissingObjectError",
     "NotConfiguredError",
     "OperationConflictError",
-    "SlackWebException",
     "UnknownDockerImageError",
     "UnknownUserError",
 ]
-
-
-class ClientRequestError(SlackIgnoredException):
-    """Represents an input validation error.
-
-    There is a global handler for this exception and all exceptions derived
-    from it that returns an status code with a body that's consistent with the
-    error messages generated internally by FastAPI.  It should be used for
-    input and parameter validation errors that cannot be caught by FastAPI for
-    whatever reason.
-
-    Exceptions inheriting from this class should set the class variable
-    ``error`` to a unique error code for that error, and the class variable
-    ``status_code`` to the HTTP status code this exception should generate.
-
-    Attributes
-    ----------
-    location
-        Part of the request giving rise to the error. This can be set by
-        catching the exception in the part of the code that knows where the
-        data came from, setting this attribute, and re-raising the exception.
-    field_path
-        Field, as a hierarchical list of structure elements, within that part
-        of the request giving rise to the error.  As with ``location``, can be
-        set by catching and re-raising.
-
-    Parameters
-    ----------
-    message
-        Error message (used as the ``msg`` key).
-    location
-        Part of the request giving rise to the error.
-    field_path
-        Field, as a hierarchical list of structure elements, in that part of
-        the request giving rise to the error.
-
-    Notes
-    -----
-    The FastAPI body format supports returning multiple errors at a time as a
-    list in the ``details`` key.  This functionality has not yet been
-    implemented.
-    """
-
-    error: ClassVar[str] = "validation_failed"
-    """Used as the ``type`` field of the error message.
-
-    Should be overridden by any subclass.
-    """
-
-    status_code: ClassVar[int] = status.HTTP_422_UNPROCESSABLE_ENTITY
-    """HTTP status code for this type of validation error."""
-
-    def __init__(
-        self,
-        message: str,
-        location: ErrorLocation | None = None,
-        field_path: list[str] | None = None,
-    ) -> None:
-        super().__init__(message)
-        self.location = location
-        self.field_path = field_path
-
-    def to_dict(self) -> dict[str, list[str] | str]:
-        """Convert the exception to a dictionary suitable for the exception.
-
-        Returns
-        -------
-        dict
-            Serialized error emssage to pass as the ``detail`` parameter to a
-            ``fastapi.HTTPException``.  It is designed to produce the same
-            JSON structure as native FastAPI errors.
-        """
-        result: dict[str, list[str] | str] = {
-            "msg": str(self),
-            "type": self.error,
-        }
-        if self.location:
-            if self.field_path:
-                result["loc"] = [self.location.value, *self.field_path]
-            else:
-                result["loc"] = [self.location.value]
-        return result
 
 
 class FileserverCreationError(ClientRequestError):
@@ -508,109 +422,6 @@ class MissingSecretError(MissingObjectError):
         super().__init__(
             message, kind="Secret", namespace=namespace, name=name
         )
-
-
-class SlackWebException(SlackException):
-    """An HTTP request to a remote service failed.
-
-    Parameters
-    ----------
-    message
-        Exception string value, which is the default Slack message.
-    failed_at
-        When the exception happened. Omit to use the current time.
-    method
-        Method of request.
-    url
-        URL of the request.
-    user
-        Username on whose behalf the request is being made.
-    status
-        Status code of failure, if any.
-    body
-        Body of failure message, if any.
-    """
-
-    @classmethod
-    def from_exception(cls, exc: HTTPError, user: str | None = None) -> Self:
-        """Create an exception from an httpx exception.
-
-        Parameters
-        ----------
-        exc
-            Exception from httpx.
-        user
-            User on whose behalf the request is being made, if known.
-
-        Returns
-        -------
-        SlackWebException
-            Newly-constructed exception.
-        """
-        if isinstance(exc, HTTPStatusError):
-            status = exc.response.status_code
-            method = exc.request.method
-            message = f"Status {status} from {method} {exc.request.url}"
-            return cls(
-                message,
-                method=exc.request.method,
-                url=str(exc.request.url),
-                user=user,
-                status=status,
-                body=exc.response.text,
-            )
-        else:
-            message = f"{type(exc).__name__}: {exc!s}"
-            if isinstance(exc, RequestError):
-                return cls(
-                    message,
-                    method=exc.request.method,
-                    url=str(exc.request.url),
-                    user=user,
-                )
-            else:
-                return cls(message, user=user)
-
-    def __init__(
-        self,
-        message: str,
-        *,
-        failed_at: datetime | None = None,
-        method: str | None = None,
-        url: str | None = None,
-        user: str | None = None,
-        status: int | None = None,
-        body: str | None = None,
-    ) -> None:
-        self.message = message
-        self.method = method
-        self.url = url
-        self.status = status
-        self.body = body
-        super().__init__(message, user, failed_at=failed_at)
-
-    def __str__(self) -> str:
-        result = self.message
-        if self.body:
-            result += f"\nBody:\n{self.body}\n"
-        return result
-
-    def to_slack(self) -> SlackMessage:
-        """Convert to a Slack message for Slack alerting.
-
-        Returns
-        -------
-        SlackMessage
-            Slack message suitable for posting as an alert.
-        """
-        message = super().to_slack()
-        if self.url:
-            text = f"{self.method} {self.url}" if self.method else self.url
-            message.blocks.append(SlackTextField(heading="URL", text=text))
-        if self.body:
-            block = SlackCodeBlock(heading="Response", code=self.body)
-            message.blocks.append(block)
-        return message
 
 
 class DockerRegistryError(SlackWebException):


### PR DESCRIPTION
Safir now provides ClientRequestError (and its handler) and SlackWebException, with some improvements. Use those exceptions from Safir rather than defining our own.