### PR TITLE
DM-41350: Properly track terminated pods

### DIFF
--- a/tests/services/lab_test.py
+++ b/tests/services/lab_test.py
@@ -88,6 +88,7 @@ async def create_lab(
     )
     await lab_storage.create(objects)
 
+    phase = PodPhase(mock_kubernetes.initial_pod_phase)
     return UserLabState(
         env=lab.env,
         user=UserInfo.from_gafaelfawr(user),
@@ -101,7 +102,7 @@ async def create_lab(
             memory=int(user.quota.notebook.memory * 1024 * 1024 * 1024),
         ),
         resources=resources,
-        status=LabStatus.from_phase(mock_kubernetes.initial_pod_phase),
+        status=LabStatus.from_phase(phase),
     )
 
 


### PR DESCRIPTION
Rather than rolling terminated pods into the error status, track them separately, still allowing them to be automatically deleted when a new spawn is requested. Add some more logging on spawn conflicts to aid in debugging.

This does not yet clean up terminated pods, just enables proper state tracking for them so that they can be cleaned up in a subsequent change.