### PR TITLE
DM-41350: Delete not-running labs during reconciliation

### DIFF
--- a/src/jupyterlabcontroller/factory.py
+++ b/src/jupyterlabcontroller/factory.py
@@ -396,3 +396,15 @@ class Factory:
         """
         await self._context.start()
         self._background_services_started = True
+
+    async def stop_background_services(self) -> None:
+        """Stop global background services managed by the process context.
+
+        These are normally stopped when closing down the global context, but
+        the test suite may want to stop and start them independently.
+
+        Only used by the test suite.
+        """
+        if self._background_services_started:
+            await self._context.stop()
+        self._background_services_started = False

--- a/src/jupyterlabcontroller/models/v1/lab.py
+++ b/src/jupyterlabcontroller/models/v1/lab.py
@@ -52,7 +52,15 @@ class LabSize(str, Enum):
 
 
 class LabStatus(Enum):
-    """Possible states the user's lab may be in."""
+    """Possible states the user's lab may be in.
+
+    This is not directly equivalent to pod phases. It is instead intended to
+    capture the status of the lab from an infrastructure standpoint,
+    reflecting the current intent of the controller. Most notably, labs that
+    have stopped running for any reason (failure or success) use the
+    terminated status. The failed status is reserved for failed Kubernetes
+    operations or missing or invalid Kubernetes objects.
+    """
 
     PENDING = "pending"
     RUNNING = "running"
@@ -83,9 +91,9 @@ class LabStatus(Enum):
                 return cls.PENDING
             case PodPhase.RUNNING:
                 return cls.RUNNING
-            case PodPhase.SUCCEEDED:
+            case PodPhase.SUCCEEDED | PodPhase.FAILED:
                 return cls.TERMINATED
-            case PodPhase.FAILED | PodPhase.UNKNOWN:
+            case PodPhase.UNKNOWN:
                 return cls.FAILED
 
 

--- a/tests/handlers/labs_test.py
+++ b/tests/handlers/labs_test.py
@@ -178,14 +178,14 @@ async def test_lab_start_stop(
         ]
     }
 
-    # Change the pod phase. This should throw the lab into a failed state.
+    # Change the pod phase. This should throw the lab into a terminated state.
     name = f"{user.username}-nb"
     namespace = f"userlabs-{user.username}"
     pod = await mock_kubernetes.read_namespaced_pod(name, namespace)
     pod.status.phase = PodPhase.FAILED.value
     r = await client.get(f"/nublado/spawner/v1/labs/{user.username}")
     assert r.status_code == 200
-    expected["status"] = "failed"
+    expected["status"] = "terminated"
     assert r.json() == expected
 
     # Delete the pod out from under the controller. This should also change
@@ -193,6 +193,7 @@ async def test_lab_start_stop(
     await mock_kubernetes.delete_namespaced_pod(name, namespace)
     r = await client.get(f"/nublado/spawner/v1/labs/{user.username}")
     assert r.status_code == 200
+    expected["status"] = "failed"
     expected["pod"] = "missing"
     assert r.json() == expected
 
@@ -228,7 +229,7 @@ async def test_spawn_after_failure(
         f"{TEST_BASE_URL}/nublado/spawner/v1/labs/{user.username}"
     )
 
-    # Change the pod phase. This should throw the lab into a failed state.
+    # Change the pod phase. This should throw the lab into a terminated state.
     name = f"{user.username}-nb"
     namespace = f"userlabs-{user.username}"
     await mock_kubernetes.patch_namespaced_pod_status(
@@ -244,7 +245,7 @@ async def test_spawn_after_failure(
     )
     r = await client.get(f"/nublado/spawner/v1/labs/{user.username}")
     assert r.status_code == 200
-    assert r.json()["status"] == "failed"
+    assert r.json()["status"] == "terminated"
 
     # Create the lab again. This should not fail with a conflict; instead, it
     # should delete the old lab and then create a new one.
@@ -449,7 +450,7 @@ async def test_abort_spawn(
     r = await client.get(f"/nublado/spawner/v1/labs/{user.username}")
     assert r.status_code == 404
     with pytest.raises(ApiException) as excinfo:
-        await mock_kubernetes.read_namespace(f"{user.username}-nb")
+        await mock_kubernetes.read_namespace(f"userlabs-{user.username}")
     assert excinfo.value.status == 404
 
 
@@ -756,6 +757,9 @@ async def test_spawn_errors(
             },
         ]
         mock_slack.messages = []
+        r = await client.get(f"/nublado/spawner/v1/labs/{user.username}")
+        assert r.status_code == 200
+        assert r.json()["status"] == "failed"
         r = await client.delete(f"/nublado/spawner/v1/labs/{user.username}")
         assert r.status_code == 204
 

--- a/tests/handlers/user_status_test.py
+++ b/tests/handlers/user_status_test.py
@@ -81,7 +81,7 @@ async def test_user_status(
     }
     assert r.json() == expected
 
-    # Change the pod phase. This should throw the lab into a failed state.
+    # Change the pod phase. This should throw the lab into a terminated state.
     name = f"{user.username}-nb"
     namespace = f"userlabs-{user.username}"
     pod = await mock_kubernetes.read_namespaced_pod(name, namespace)
@@ -90,7 +90,7 @@ async def test_user_status(
         "/nublado/spawner/v1/user-status", headers=user.to_headers()
     )
     assert r.status_code == 200
-    expected["status"] = "failed"
+    expected["status"] = "terminated"
     assert r.json() == expected
 
     # Delete the pod out from under the controller. This should also change
@@ -100,5 +100,6 @@ async def test_user_status(
         "/nublado/spawner/v1/user-status", headers=user.to_headers()
     )
     assert r.status_code == 200
+    expected["status"] = "failed"
     expected["pod"] = "missing"
     assert r.json() == expected


### PR DESCRIPTION
When we encounter a lab in a terminated state during background reconciliation (labs that were OOMKilled, idle-culled, etc.), delete the lab. Do this carefully to avoid conflicts with a user operation that might race with us, since it should get precedence. Similarly clean up labs that are in a failed state.

Convert a pod status of Failed to a lab status of terminated, not failed. Use failed to indicate missing Kubernetes resources or similar errors, and terminated to mean that the pod has stopped for whatever reason.