### PR TITLE
DM-41188: Rework state management for file servers

### DIFF
--- a/src/jupyterlabcontroller/constants.py
+++ b/src/jupyterlabcontroller/constants.py
@@ -9,6 +9,7 @@ __all__ = [
     "DOCKER_SECRETS_PATH",
     "DROPDOWN_SENTINEL_VALUE",
     "GROUPNAME_REGEX",
+    "FILE_SERVER_REFRESH_INTERVAL",
     "IMAGE_REFRESH_INTERVAL",
     "KUBERNETES_DELETE_TIMEOUT",
     "KUBERNETES_REQUEST_TIMEOUT",
@@ -44,6 +45,13 @@ DOCKER_SECRETS_PATH = Path("/etc/secrets/.dockerconfigjson")
 
 DROPDOWN_SENTINEL_VALUE = "use_image_from_dropdown"
 """Used in the lab form for ``image_list`` when ``image_dropdown`` is used."""
+
+FILE_SERVER_REFRESH_INTERVAL = timedelta(minutes=60)
+"""How frequently to refresh file server state from Kubernetes.
+
+This will detect when file servers disappear out from under us, such as being
+terminated by Kubernetes node replacements or upgrades.
+"""
 
 IMAGE_REFRESH_INTERVAL = timedelta(minutes=5)
 """How frequently to refresh the list of remote and cached images."""

--- a/src/jupyterlabcontroller/factory.py
+++ b/src/jupyterlabcontroller/factory.py
@@ -133,6 +133,7 @@ class ProcessContext:
                 fileserver_storage=FileserverStorage(
                     kubernetes_client, logger
                 ),
+                slack_client=slack_client,
                 logger=logger,
             )
 

--- a/src/jupyterlabcontroller/models/domain/kubernetes.py
+++ b/src/jupyterlabcontroller/models/domain/kubernetes.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Self
 
-from kubernetes_asyncio.client import V1ContainerImage, V1ObjectMeta
+from kubernetes_asyncio.client import V1ContainerImage, V1ObjectMeta, V1Pod
 from typing_extensions import Protocol
 
 from .docker import DockerReference
@@ -112,3 +112,14 @@ class PodPhase(str, Enum):
     SUCCEEDED = "Succeeded"
     FAILED = "Failed"
     UNKNOWN = "Unknown"
+
+
+@dataclass
+class PodChange:
+    """Represents a change (not creation or deletion) of a pod."""
+
+    phase: PodPhase
+    """New phase of the pod."""
+
+    pod: V1Pod
+    """Full object for the pod that changed."""

--- a/src/jupyterlabcontroller/services/lab.py
+++ b/src/jupyterlabcontroller/services/lab.py
@@ -832,14 +832,15 @@ class LabManager:
     async def _reconcile_loop(self) -> None:
         """Run in the background by `start`, stopped with `stop`."""
         while True:
-            start = current_datetime()
+            start = current_datetime(microseconds=True)
             try:
                 await self._reconcile_lab_state()
             except Exception as e:
                 self._logger.exception("Unable to reconcile user lab state")
                 if self._slack:
                     await self._slack.post_uncaught_exception(e)
-            delay = LAB_STATE_REFRESH_INTERVAL - (current_datetime() - start)
+            now = current_datetime(microseconds=True)
+            delay = LAB_STATE_REFRESH_INTERVAL - (now - start)
             if delay.total_seconds() < 1:
                 msg = "User lab state reconciliation is running continuously"
                 self._logger.warning(msg)


### PR DESCRIPTION
Use the same pattern as the new state management in LabManager: a dictionary of state objects per user, where the user is never removed once we've seen them. In this case, the state object only needs to hold a lock, not a full-blown manager class.

Rather than spawning a separate background task (and Kubernetes watch) for every running file server, use a single background task that watches for all pod changes in the namespace. Use that to catch pod phase changes. Add a background reconcile task to look for any other problems (such as Kubernetes object deletion) and clean up after those.

Add Slack reporting of errors in file server operations.